### PR TITLE
Concurrent AVP encoding issue - AvpDataException: Not enough data in buffer! (fixes #1)

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/AvpSetImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/AvpSetImpl.java
@@ -37,7 +37,10 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.jdiameter.api.Avp;
+import org.jdiameter.api.AvpDataException;
 import org.jdiameter.api.AvpSet;
 import org.jdiameter.api.InternalException;
 import org.jdiameter.api.URI;
@@ -53,6 +56,8 @@ class AvpSetImpl implements AvpSet {
 
   // FIXME: by default 3588.4-1 says: 'M' should be set to true;
   // FIXME: by default 3588.x says: if grouped has at least on AVP with 'M' set, it also has to have 'M' set! - TODO: add backmapping.
+	
+  private static final Logger logger = LoggerFactory.getLogger(AvpSetImpl.class);
   
   private static final long serialVersionUID = 1L;
   private static final ElementParser parser = new ElementParser();
@@ -187,10 +192,15 @@ class AvpSetImpl implements AvpSet {
     }
 
     public AvpSet insertGroupedAvp(int index, int avpCode) {
-        AvpImpl res = new AvpImpl(avpCode, 0, 0, new byte[0]);
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, 0, 0, null);
         this.avps.add(index, res);
-        return res.groupedData;
+        
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("insert avp failed", e);
+		}
+        return null;
     }
 
     public int size() {
@@ -421,26 +431,41 @@ class AvpSetImpl implements AvpSet {
     }
 
     public AvpSet addGroupedAvp(int avpCode) {
-        AvpImpl res = new AvpImpl(avpCode, 0, 0, new byte[0] );
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, 0, 0, null);
         this.avps.add(res);
-        return res.groupedData;
+        
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("add avp failed", e);
+		}
+        return null;
     }
 
     public AvpSet addGroupedAvp(int avpCode, boolean mFlag, boolean pFlag) {
         int flags = ((mFlag ? 0x40:0) | (pFlag ? 0x20:0));
-        AvpImpl res = new AvpImpl(avpCode, flags, 0, new byte[0] );
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, flags, 0, null);
         this.avps.add(res);
-        return res.groupedData;
+        
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("add avp failed", e);
+		}
+        return null;
     }
 
     public AvpSet addGroupedAvp(int avpCode, long vndId, boolean mFlag, boolean pFlag) {
         int flags = ((vndId !=0 ? 0x80:0) | (mFlag ? 0x40:0) | (pFlag ? 0x20:0));
-        AvpImpl res = new AvpImpl(avpCode, flags, vndId, new byte[0] );
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, flags, vndId, null);
         this.avps.add(res);
-        return res.groupedData;
+        
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("add avp failed", e);
+		}
+        return null;
     }
 
     public Avp insertAvp(int index, int avpCode, byte[] value) {
@@ -654,18 +679,28 @@ class AvpSetImpl implements AvpSet {
 
     public AvpSet insertGroupedAvp(int index, int avpCode, boolean mFlag, boolean pFlag) {
         int flags = ((mFlag ? 0x40:0) | (pFlag ? 0x20:0));
-        AvpImpl res = new AvpImpl(avpCode, flags, 0, new byte[0] );
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, flags, 0, null);
         this.avps.add(index, res);
-        return res.groupedData;
+
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("insert avp failed", e);
+		}
+        return null;
     }
 
     public AvpSet insertGroupedAvp(int index, int avpCode, long vndId, boolean mFlag, boolean pFlag) {
         int flags = ((vndId !=0 ? 0x80:0) | (mFlag ? 0x40:0) | (pFlag ? 0x20:0));
-        AvpImpl res = new AvpImpl(avpCode, flags, vndId, new byte[0] );
-        res.groupedData = new AvpSetImpl();
+        AvpImpl res = new AvpImpl(avpCode, flags, vndId, null);
         this.avps.add(index, res);
-        return res.groupedData;
+        
+        try {
+			return res.getGrouped();
+		} catch (AvpDataException e) {
+			logger.error("insert avp failed", e);
+		}
+        return null;
     }
 
     public boolean isWrapperFor(Class<?> aClass) throws InternalException {

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java
@@ -25,6 +25,7 @@ package org.jdiameter.client.impl.parser;
 import org.jdiameter.api.Avp;
 import org.jdiameter.api.AvpDataException;
 import org.jdiameter.api.AvpSet;
+import org.jdiameter.api.InternalException;
 import org.jdiameter.client.api.parser.ParseException;
 import org.jdiameter.client.api.parser.IElementParser;
 import org.slf4j.Logger;
@@ -50,7 +51,7 @@ import java.util.Date;
  */
 public class ElementParser implements IElementParser {
 
-  private static final Logger logger = LoggerFactory.getLogger(ElementParser.class);
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(ElementParser.class);
     /**
      * This is seconds shift (70 years in seconds) applied to date, 
      * since NTP date starts since 1900, not 1970.
@@ -251,6 +252,42 @@ public class ElementParser implements IElementParser {
     public AvpSetImpl decodeAvpSet(byte[] buffer) throws IOException, AvpDataException {
       return this.decodeAvpSet(buffer, 0);
     }
+    
+    private String fullDecode(byte[] buffer, int shift) throws IOException {
+    	DataInputStream in = new DataInputStream(new ByteArrayInputStream(buffer, shift, buffer.length));
+    	StringBuilder sb = new StringBuilder();
+    	
+    	int read = shift;
+    	while (read < buffer.length) {
+    		int code = in.readInt();
+    		int flags = in.readInt();
+    		int consumed = 8;
+    		
+    		int vendor = ((flags & 0x80) != 0) ? in.readInt() : -1;
+    		if (vendor != -1) {
+    			consumed += 4;
+    		}
+    		
+    		int length = (int)(flags & 0xFFFFFF) - consumed;
+    		int padding = ((length % 4) != 0) ? (4 - (length % 4)) : 0;
+    		length += padding;
+    		
+    		int num_read = ((read + consumed + length) > buffer.length) ? (buffer.length-consumed-read) : length;
+    		int skip = num_read;
+    		
+    		while (skip > 0) {
+    			skip -= in.skipBytes(skip);
+    		}
+    		
+    		read += (consumed + num_read);
+    		
+    		sb.append(" code: ").append(code).append(" flags: ").append(flags)
+    		  .append(" len: ").append(length).append(" pad: ").append(padding)
+    		  .append(" skip: ").append(skip).append(" read: ").append(read).append("\n");
+    	}
+    	
+    	return sb.toString();
+    }
 
     /**
      * 
@@ -262,6 +299,11 @@ public class ElementParser implements IElementParser {
      */
     public AvpSetImpl decodeAvpSet(byte[] buffer, int shift) throws IOException, AvpDataException {
       AvpSetImpl avps = new AvpSetImpl();
+      
+      if (buffer == null) {
+    	  return avps; // empty
+      }
+      
       int tmp, counter = shift;
       DataInputStream in = new DataInputStream(new ByteArrayInputStream(buffer, shift, buffer.length /* - shift ? */));
 
@@ -270,8 +312,11 @@ public class ElementParser implements IElementParser {
         tmp = in.readInt();
         int flags = (tmp >> 24) & 0xFF;
         int length  = tmp & 0xFFFFFF;
+        
         if(length < 0 || counter + length > buffer.length) {
-          throw new AvpDataException("Not enough data in buffer!");
+        	logger.error("unable to decode code: {}, flags: {}, length: {}, counter: {}, shift:{}, buf_size: {}\n{}\n{}",
+        			new Object[]{code, (short)flags, length, counter, shift, buffer.length, MessageParser.byteArrayToHexString(buffer), fullDecode(buffer,shift)});
+        	throw new AvpDataException("Not enough data in buffer!");
         }
         long vendor = 0;
         if ((flags & 0x80) != 0) {
@@ -295,33 +340,44 @@ public class ElementParser implements IElementParser {
     }
     
     public byte[] encodeAvpSet(AvpSet avps) {
+    	return encodeAvpSet(avps, null, "");
+    }
+    
+    public byte[] encodeAvpSet(AvpSet avps, StringBuilder sb, String prefix) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
           DataOutputStream data = new DataOutputStream(out);
           for (Avp a : avps) {
-            if (a instanceof AvpImpl) {
-              AvpImpl aImpl = (AvpImpl) a;
-              if (aImpl.rawData.length == 0 && aImpl.groupedData != null) {
-                aImpl.rawData = encodeAvpSet(a.getGrouped());
+        	  byte[] raw = a.getRaw();
+              byte[] enc = encodeAvp(a);
+              
+              if (sb != null) {
+            	  sb.append(prefix).append(a).append(", len: ").append((raw != null) ? raw.length : null)
+            	  	.append(", enc: ").append(MessageParser.byteArrayToHexStringLine(enc)).append("\n");
               }
-              data.write(encodeAvp(aImpl));
-            }
+              
+              data.write(enc);
           }
-        }
-        catch (Exception e) {
-          logger.debug("Error during encode avps", e);
+        } catch (Exception e) {
+          logger.error("Error during encode avps", e);
         }
         return out.toByteArray();
-      }
+    }
     
-    public byte[] encodeAvp(AvpImpl avp) {
+    public byte[] encodeAvp(Avp avp) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
           DataOutputStream data = new DataOutputStream(out);
           data.writeInt(avp.getCode());
           int flags = (byte) ((avp.getVendorId() != 0 ? 0x80 : 0) |
               (avp.isMandatory() ? 0x40 : 0) | (avp.isEncrypted() ? 0x20 : 0));
-          int origLength = avp.getRaw().length + 8 + (avp.getVendorId() != 0 ? 4 : 0);
+          
+          byte[] raw = avp.getRaw();
+          if (raw == null) {
+        	  raw = encodeAvpSet(avp.getGrouped());
+          }
+          
+          int origLength = raw.length + 8 + (avp.getVendorId() != 0 ? 4 : 0);
           // newLength is never used. Should it?
           //int newLength  = origLength;
           //if (newLength % 4 != 0) {
@@ -331,9 +387,9 @@ public class ElementParser implements IElementParser {
           if (avp.getVendorId() != 0) {
             data.writeInt((int) avp.getVendorId());
           }
-          data.write(avp.getRaw());
-          if (avp.getRaw().length % 4 != 0) {
-            for(int i = 0; i < 4 - avp.getRaw().length % 4; i++) {
+          data.write(raw);
+          if (raw.length % 4 != 0) {
+            for(int i = 0; i < 4 - raw.length % 4; i++) {
               data.write(0);
             }
           }

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/TCPClientConnection.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/TCPClientConnection.java
@@ -32,6 +32,7 @@ import org.jdiameter.client.api.io.IConnectionListener;
 import org.jdiameter.client.api.io.TransportError;
 import org.jdiameter.client.api.io.TransportException;
 import org.jdiameter.client.api.parser.IMessageParser;
+import org.jdiameter.client.impl.parser.MessageParser;
 import org.jdiameter.common.api.concurrent.IConcurrentFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +56,7 @@ import java.util.concurrent.locks.ReentrantLock;
  */
 public class TCPClientConnection implements IConnection {
 
-  private static Logger logger = LoggerFactory.getLogger(TCPClientConnection.class);
+  private static org.slf4j.Logger logger = LoggerFactory.getLogger(TCPClientConnection.class);
 
   private final long createdTime;
   private TCPTransportClient client;
@@ -263,7 +264,13 @@ public class TCPClientConnection implements IConnection {
 
   protected void onMessageReceived(ByteBuffer message) throws AvpDataException {
     if (logger.isDebugEnabled()) {
-      logger.debug("Received message of size [{}]", message.array().length);
+    	if (logger.isTraceEnabled()) {
+	    	String hex = MessageParser.byteArrayToHexString(message.array());
+	    	logger.trace("Received message of size [{}]\n{}", 
+	    		  new Object[] {message.array().length, hex});
+    	} else {
+    		logger.debug("Received message of size [{}]", message.array().length);
+    	}
     }
     onEvent(new Event(EventType.MESSAGE_RECEIVED, message));
   }

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/TCPTransportClient.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/TCPTransportClient.java
@@ -44,6 +44,7 @@ package org.jdiameter.client.impl.transport.tcp;
 
 import org.jdiameter.api.AvpDataException;
 import org.jdiameter.client.api.io.NotInitializedException;
+import org.jdiameter.client.impl.parser.MessageParser;
 import org.jdiameter.common.api.concurrent.IConcurrentFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,7 @@ public class TCPTransportClient implements Runnable {
 
   private String socketDescription = null;
 
-  private static final Logger logger = LoggerFactory.getLogger(TCPTransportClient.class);
+  private static final org.slf4j.Logger logger = LoggerFactory.getLogger(TCPTransportClient.class);
 
   //PCB - allow non blocking IO
   private static final boolean BLOCKING_IO = false;
@@ -290,8 +291,14 @@ public class TCPTransportClient implements Runnable {
   }
 
   public void sendMessage(ByteBuffer bytes) throws IOException {
-    if (logger.isDebugEnabled()) {
-      logger.debug("About to send a byte buffer of size [{}] over the TCP nio socket [{}]", bytes.array().length, socketDescription);
+	if (logger.isDebugEnabled()) {
+		if (logger.isTraceEnabled()) {
+			String hex = MessageParser.byteArrayToHexString(bytes.array());
+			logger.trace("About to send a byte buffer of size [{}] over the TCP nio socket [{}]\n{}", 
+	    		  new Object[]{bytes.array().length, socketDescription, hex});
+		} else {
+			logger.debug("About to send a byte buffer of size [{}] over the TCP nio socket [{}]", bytes.array().length, socketDescription);
+		}
     }
     int rc = 0;
     // PCB - removed locking

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/MutablePeerTableImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/MutablePeerTableImpl.java
@@ -623,6 +623,7 @@ public class MutablePeerTableImpl extends PeerTableImpl implements IMutablePeerT
     //TODO: add sKey here, now it adds peer to all realms.
     //TODO: better, separate addPeer from realm!
     try {
+    	logger.debug("Adding peer, URI-{}, realm-{}, connecting-{}", new Object[] {peerURI, realm, connecting});
       Configuration peerConfig = null;
       Configuration[] peers = config.getChildren(PeerTable.ordinal());
       // find peer config
@@ -647,7 +648,19 @@ public class MutablePeerTableImpl extends PeerTableImpl implements IMutablePeerT
       Collection<Realm> realms =  this.router.getRealmTable().getRealms(realm);
       for (Realm r : realms) {
         if (r.getName().equals(realm)) {
-          ((IRealm)r).addPeerName(peerURI.toString());
+        	boolean peerNameFound = false;
+        	for (String peerName : ((IRealm)r).getPeerNames()) {
+        		if (peerName != null && peerName.equals(peerURI.getFQDN())) {
+        			peerNameFound = true;
+        			break;
+        		}
+        	}
+        	if (!peerNameFound) {
+        		((IRealm)r).addPeerName(peerURI.getFQDN());
+        		logger.debug("Adding peerName-{} to realm-{}", peerURI.getFQDN(), realm);
+        	} else {
+        		logger.debug("Skipped adding peerName-{} to realm-{}, because it already exists", peerURI.getFQDN(), realm);
+        	}
           found = true;
           break;
         }

--- a/core/mux/jar/src/main/java/org/mobicents/diameter/stack/DiameterStackMultiplexer.java
+++ b/core/mux/jar/src/main/java/org/mobicents/diameter/stack/DiameterStackMultiplexer.java
@@ -641,10 +641,10 @@ public class DiameterStackMultiplexer extends ServiceMBeanSupport implements Dia
    * (non-Javadoc)
    * @see org.mobicents.diameter.stack.DiameterStackMultiplexerMBean#_Network_Peers_addPeer(java.lang.String, boolean, int)
    */
-  public void _Network_Peers_addPeer(String name, boolean attemptConnect, int rating) throws MBeanException {
+  public void _Network_Peers_addPeer(String name, boolean attemptConnect, int rating, String realm) throws MBeanException {
     try {
       NetworkImpl n = (NetworkImpl) stack.unwrap(Network.class);
-      /*Peer p =*/ n.addPeer(name, "", attemptConnect); // FIXME: This requires realm...
+      n.addPeer(name, realm, attemptConnect);
     }
     catch (IllegalArgumentException e) {
       logger.warn(e.getMessage());

--- a/core/mux/jar/src/main/java/org/mobicents/diameter/stack/DiameterStackMultiplexerMBean.java
+++ b/core/mux/jar/src/main/java/org/mobicents/diameter/stack/DiameterStackMultiplexerMBean.java
@@ -201,9 +201,10 @@ public interface DiameterStackMultiplexerMBean extends ServiceMBean {
    * @param name the name/uri of the peer
    * @param attemptConnect indicates if the stack should try to connect to this peer or wait for incoming connection
    * @param rating the peer rating for decision on message routing
+   * @param realm name of the realm
    * @throws MBeanException if the operation is unable to perform correctly
    */
-  public void _Network_Peers_addPeer(String name, boolean attemptConnect, int rating) throws MBeanException;
+  public void _Network_Peers_addPeer(String name, boolean attemptConnect, int rating, String realm) throws MBeanException;
 
   /**
    * Removes a peer definition from stack.


### PR DESCRIPTION
Hi all,

We have found 2 concurrency issues with AVP encoding/decoding when doing load tests.
1. Ecoding problem causes such exceptions:

```
2015-08-14 13:47:23,832 DEBUG [org.jdiameter.client.impl.controller.PeerImpl] (TCPReader-1) internalError
org.jdiameter.client.api.io.TransportException: Avp Data Exception:
        at org.jdiameter.client.impl.transport.tcp.TCPClientConnection.onEvent(TCPClientConnection.java:319)
        at org.jdiameter.client.impl.transport.tcp.TCPClientConnection.onAvpDataException(TCPClientConnection.java:276)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.seekMessage(TCPTransportClient.java:446)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.append(TCPTransportClient.java:392)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.run(TCPTransportClient.java:213)
        at java.lang.Thread.run(Thread.java:745)
Caused by: org.jdiameter.api.AvpDataException: org.jdiameter.api.AvpDataException: Not enough data in buffer!
        at org.jdiameter.client.impl.parser.MessageParser.createMessage(MessageParser.java:121)
        at org.jdiameter.client.impl.transport.tcp.TCPClientConnection.onEvent(TCPClientConnection.java:314)
        at org.jdiameter.client.impl.transport.tcp.TCPClientConnection.onMessageReceived(TCPClientConnection.java:271)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.seekMessage(TCPTransportClient.java:440)
        ... 3 more
Caused by: org.jdiameter.api.AvpDataException: Not enough data in buffer!
        at org.jdiameter.client.impl.parser.ElementParser.decodeAvpSet(ElementParser.java:319)
        at org.jdiameter.client.impl.parser.MessageParser.createMessage(MessageParser.java:116)
        ... 6 more
```

And also a BufferOverflow in the end:

```
        2015-08-14 13:47:23,835 ERROR [org.jdiameter.client.impl.transport.tcp.TCPTransportClient] (TCPReader-1) Buffer overflow occured
java.nio.BufferOverflowException
        at java.nio.HeapByteBuffer.put(HeapByteBuffer.java:183)
        at java.nio.ByteBuffer.put(ByteBuffer.java:832)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.append(TCPTransportClient.java:385)
        at org.jdiameter.client.impl.transport.tcp.TCPTransportClient.run(TCPTransportClient.java:213)
        at java.lang.Thread.run(Thread.java:745)
```

Problem - encoded/decoded Diameter packets get corrupted (missing child AVPs). 

Reason - This is due to the fact that the function [getGrouped](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/AvpImpl.java#L225) that converts AvpImpl.java _rawData_ to _groupedData_ is called `concurrently` when doing [encodeAvpSet()](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java#L297). If this is done in the loop before [data.write(raw)](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java#L334) operation in encodeAvpSet, then all child AVPs could be left unencoded (not written) to the packet (since avp.getRaw().length becomes 0). And since a correct AVP length is written [here](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java#L330), the packet gets corrupted.

2.We also obtained a `NullpointerException` in [SessionImpl.java](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/SessionImpl.java#L138), when doing a release, due to the fact that container concurrently was set to `null` via [setContainer](https://github.com/Mobicents/jdiameter/blob/master/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/SessionImpl.java#L54), so this was also fixed. However, don't know what the "// FIXME" is for, but I guess it relates to the same problem.

With this pull I propose a possible fix for this issue. Also to encapsulate more the existing data in AvpImpl.java, i.e. make rawData/groupedData not accessible from outside. ALSO to forbid to swap between rawData/groupedData in runtime, i.e. to not change created AVP.
