### PR TITLE
Simple traffic load balancing among peers

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
@@ -1,0 +1,202 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2016, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+package org.jdiameter.client.impl.router;
+
+import org.jdiameter.api.Configuration;
+import org.jdiameter.api.MetaData;
+import org.jdiameter.api.PeerState;
+import org.jdiameter.client.api.IContainer;
+import org.jdiameter.client.api.controller.IPeer;
+import org.jdiameter.client.api.controller.IRealmTable;
+import org.jdiameter.common.api.concurrent.IConcurrentFactory;
+import org.jdiameter.common.api.statistic.IStatistic;
+import org.jdiameter.common.api.statistic.IStatisticRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Weighted Least-Connections router implementation<br/><br/>
+ *
+ * This requires that {@link IStatistic Statistics} for the following records are enabled: Peer,AppGenRequestPerSecond,NetGenRequestPerSecond
+ * In the client configuration, please use the following settings:
+ *
+ * <pre>
+ *   ...
+ *   <Parameters>
+ *      <Statistics pause="5000" delay="5000" enabled="true" active_records="Peer,AppGenRequestPerSecond,NetGenRequestPerSecond"/>
+ *   </Parameters>
+ *   ...
+ *   <Extensions>
+ *     <RouterEngine value="org.jdiameter.client.impl.router.WeightedLeastConnectionsRouter" />
+ *   </Extensions>
+ * </pre>
+ *
+ * @see <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling</a>
+ * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
+ */
+public class WeightedLeastConnectionsRouter extends RouterImpl {
+
+    private static final Logger logger = LoggerFactory.getLogger(WeightedLeastConnectionsRouter.class);
+
+    protected WeightedLeastConnectionsRouter(IRealmTable table, Configuration config) {
+        super(null, null, table, config, null);
+    }
+
+    public WeightedLeastConnectionsRouter(IContainer container, IConcurrentFactory concurrentFactory,
+                                          IRealmTable realmTable, Configuration config, MetaData aMetaData) {
+        super(container, concurrentFactory, realmTable, config, aMetaData);
+    }
+
+    /**
+     * Return peer with least connections<br/>
+     * {@url http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling}
+     *
+     * <p>
+     * The weighted least-connection scheduling is a superset of the least-connection scheduling,
+     * in which you can assign a performance weight to each real server. The servers with a higher
+     * weight value will receive a larger percentage of active connections at any one time.
+     * The default server weight is one, and the IPVS Administrator or monitoring program can
+     * assign any weight to real server. In the weighted least-connections scheduling, new
+     * network connection is assigned to a server which has the least ratio of the current
+     * active connection number to its weight.
+     * <p>
+     * Supposing there is a server set S = {S0, S1, ..., Sn-1},
+     * W(Si) is the weight of server Si;
+     * C(Si) is the current connection number of server Si;
+     * CSUM = ΣC(Si) (i=0, 1, .. , n-1) is the sum of current connection numbers;
+     * <p>
+     * The new connection is assigned to the server j, in which
+     * (C(Sm) / CSUM)/ W(Sm) = min { (C(Si) / CSUM) / W(Si)}  (i=0, 1, . , n-1),
+     * where W(Si) isn't zero
+     * Since the CSUM is a constant in this lookup, there is no need to divide by CSUM,
+     * the condition can be optimized as
+     * C(Sm) / W(Sm) = min { C(Si) / W(Si)}  (i=0, 1, . , n-1), where W(Si) isn't zero
+     * <p>
+     * Since division operation eats much more CPU cycles than multiply operation, and Linux
+     * does not allow float mode inside the kernel, the condition C(Sm)/W(Sm) > C(Si)/W(Si)
+     * can be optimized as C(Sm)*W(Si) > C(Si)*W(Sm). The scheduling should guarantee
+     * that a server will not be scheduled when its weight is zero. Therefore, the pseudo
+     * code of weighted least-connection scheduling algorithm is
+     * <p>
+     * <pre>
+     * {@code
+     *   for (m = 0; m < n; m++) {
+     *     if (W(Sm) > 0) {
+     *       for (i = m+1; i < n; i++) {
+     *         if (C(Sm)*W(Si) > C(Si)*W(Sm))
+     *           m = i;
+     *       }
+     *       return Sm;
+     *     }
+     *   }
+     *   return NULL;
+     * }
+     * </pre>
+     * <p>
+     * The weighted least-connection scheduling algorithm requires additional division than
+     * the least-connection scheduling. In a hope to minimize the overhead of scheduling when
+     * servers have the same processing capacity, both the least-connection scheduling and the
+     * weighted least-connection scheduling algorithms are implemented.
+     *
+     * @see <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling</a>
+     * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
+     * @return the selected peer according to algorithm
+     */
+    @Override
+    public IPeer selectPeer(List<IPeer> availablePeers) {
+        int peerSize = availablePeers != null ? availablePeers.size() : 0;
+
+        // Return none if empty, or first if only one member found
+        if (peerSize <= 0) return null;
+        if (peerSize == 1) return availablePeers.iterator().next();
+
+        for (int m = 0; m < peerSize; peerSize++) {
+            IPeer peerM = availablePeers.get(m);
+            if (peerM.getRating() > 0) {
+                for (int i = m + 1; i < peerSize; i++) {
+                    IPeer peerI = availablePeers.get(i);
+                    if (getNumConnections(peerM) * peerI.getRating() > getNumConnections(peerI) * peerM.getRating()) {
+                        m = i;
+                    }
+                }
+                return availablePeers.get(m);
+            }
+        }
+
+        // Return first peer if anything did go wrong
+        return availablePeers.iterator().next();
+    }
+
+    /**
+     * Since num connections is not available, determine throughput by reading statistics
+     * and assume the load of the peer
+     *
+     * @param peer
+     * @return throughput indicator
+     */
+    protected long getNumConnections(IPeer peer) {
+        if (peer == null) return 0;
+        IStatistic stats = peer.getStatistic();
+
+        // If no statistics are available, return zero
+        if (!stats.isEnabled()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Statistics for peer are disabled. Please enable statistics in client config");
+            }
+            return 0;
+        }
+
+        // Requests per second initiated by Local Peer + Request initiated by Remote peer
+        String uri = peer.getUri() == null ? "local" : peer.getUri().toString();
+        long requests = getRecord(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+uri, stats)
+                + getRecord(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+uri, stats);
+
+        // There are likely more requests than responses active
+        long connections = Math.max(0, requests);
+
+        if (logger.isTraceEnabled()) {
+            logger.trace("Active connections for {}: {}", peer, connections);
+        }
+
+        return connections;
+    }
+
+    /**
+     * Return statistics record value from given {@link IStatistic}
+     *
+     * @param record key to retrieve
+     * @param stats  statistic object
+     * @return
+     */
+    protected long getRecord(String record, IStatistic stats) {
+        if (record == null || stats == null) return 0;
+        IStatisticRecord statsRecord = stats.getRecordByName(record);
+        if (statsRecord == null) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Warning: no record for {}, available: {}", record, Arrays.toString(stats.getRecords()));
+            }
+            return 0;
+        }
+        return statsRecord.getValueAsLong();
+    }
+}

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedRoundRobinRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedRoundRobinRouter.java
@@ -1,0 +1,168 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2016, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+package org.jdiameter.client.impl.router;
+
+import org.jdiameter.api.Configuration;
+import org.jdiameter.api.MetaData;
+import org.jdiameter.api.PeerState;
+import org.jdiameter.client.api.IContainer;
+import org.jdiameter.client.api.controller.IPeer;
+import org.jdiameter.client.api.controller.IRealmTable;
+import org.jdiameter.common.api.concurrent.IConcurrentFactory;
+
+import java.util.List;
+
+/**
+ * Weighted round-robin router implementation
+ *
+ * @see <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
+ * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
+ */
+public class WeightedRoundRobinRouter extends RouterImpl {
+
+    private int lastSelectedPeer = -1;
+    private int currentWeight = 0;
+
+    protected WeightedRoundRobinRouter(IRealmTable table, Configuration config) {
+        super(null, null, table, config, null);
+    }
+
+    public WeightedRoundRobinRouter(IContainer container, IConcurrentFactory concurrentFactory,
+                                    IRealmTable realmTable, Configuration config, MetaData aMetaData) {
+        super(container, concurrentFactory, realmTable, config, aMetaData);
+    }
+
+    /**
+     * Select peer by weighted round-robin scheduling
+     * As documented in http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling
+     *
+     * <p>
+     * The weighted round-robin scheduling is designed to better handle servers
+     * with different processing capacities. Each server can be assigned a weight,
+     * an integer value that indicates the processing capacity. Servers with higher
+     * weights receive new connections first than those with less weights, and servers
+     * with higher weights get more connections than those with less weights and servers
+     * with equal weights get equal connections. The pseudo code of weighted round-robin
+     * scheduling is as follows:
+     * <p>
+     * Supposing that there is a server set S = {S0, S1, …, Sn-1};
+     * W(Si) indicates the weight of Si;
+     * i indicates the server selected last time, and i is initialized with -1;
+     * cw is the current weight in scheduling, and cw is initialized with zero;
+     * max(S) is the maximum weight of all the servers in S;
+     * gcd(S) is the greatest common divisor of all server weights in S;
+     * <p>
+     * <pre>
+     * {@code
+     *   while (true) {
+     *     i = (i + 1) mod n;
+     *     if (i == 0) {
+     *       cw = cw - gcd(S);
+     *         if (cw <= 0) {
+     *           cw = max(S);
+     *           if (cw == 0)
+     *             return NULL;
+     *         }
+     *     }
+     *     if (W(Si) >= cw)
+     *       return Si;
+     *   }
+     * }
+     * </pre>
+     * <p>
+     * For example, the real servers, A, B and C, have the weights, 4, 3, 2 respectively,
+     * a scheduling sequence will be AABABCABC in a scheduling period (mod sum(Wi)).
+     * <p>
+     * In an optimized implementation of the weighted round-robin scheduling, a scheduling sequence
+     * will be generated according to the server weights after the rules of IPVS are modified.
+     * The network connections are directed to the different real servers based on the scheduling
+     * sequence in a round-robin manner.
+     * <p>
+     * The weighted round-robin scheduling is better than the round-robin scheduling, when the
+     * processing capacity of real servers are different. However, it may lead to dynamic load
+     * imbalance among the real servers if the load of the requests vary highly. In short, there
+     * is the possibility that a majority of requests requiring large responses may be directed
+     * to the same real server.
+     * <p>
+     * Actually, the round-robin scheduling is a special instance of the weighted round-robin
+     * scheduling, in which all the weights are equal.
+     * <p>
+     * This method is internally synchronized due to concurrent modifications to lastSelectedPeer and currentWeight.
+     * Please consider this when relying on heavy throughput.
+     *
+     * Please note: if the list of availablePeers changes between calls (e.g. if a peer becomes active or inactive),
+     * the balancing algorithm is disturbed and might be distributed uneven.
+     * This is likely to happen if peers are flapping.
+     *
+     * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
+     * @return the selected peer according to algorithm
+     * @see <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
+     */
+    @Override
+    public IPeer selectPeer(List<IPeer> availablePeers) {
+
+        int peerSize = availablePeers != null ? availablePeers.size() : 0;
+
+        // Return none if empty, or first if only one member found
+        if (peerSize <= 0) return null;
+        if (peerSize == 1) return availablePeers.iterator().next();
+
+        // Find maximum weight and greatest common divisor of weight across all peers
+        int maxWeight = 0;
+        Integer gcd = null;
+        for (IPeer peer : availablePeers) {
+            maxWeight = Math.max(maxWeight, peer.getRating());
+            gcd = (gcd == null) ? peer.getRating() : gcd(gcd, peer.getRating());
+        }
+
+        // Find best matching candidate. Synchronized here due to consistent changes on member variables
+        synchronized (this) {
+            for ( ;; ) {
+                lastSelectedPeer = (lastSelectedPeer + 1) % peerSize;
+                if (lastSelectedPeer == 0) {
+                    currentWeight = currentWeight - gcd;
+                    if (currentWeight <= 0) {
+                        currentWeight = maxWeight;
+                    }
+                }
+                if (peerSize <= lastSelectedPeer) {
+                    lastSelectedPeer = -1; // safety first, restart if peer size has accidentally changed.
+                    continue;
+                }
+                IPeer candidate = availablePeers.get(lastSelectedPeer);
+                if (candidate.getRating() >= currentWeight) {
+                    return availablePeers.get(lastSelectedPeer);
+                }
+            }
+        }
+    }
+
+    /**
+     * Return greatest common divisor for two integers
+     * https://en.wikipedia.org/wiki/Greatest_common_divisor#Using_Euclid.27s_algorithm
+     *
+     * @param a
+     * @param b
+     * @return greatest common divisor
+     */
+    protected int gcd(int a, int b) {
+        return (b == 0) ? a : gcd(b, a % b);
+    }
+}

--- a/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
+++ b/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
@@ -1,0 +1,450 @@
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2016, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+package org.jdiameter.client.impl.router;
+
+import org.jdiameter.api.*;
+import org.jdiameter.api.app.StateChangeListener;
+import org.jdiameter.client.api.IAnswer;
+import org.jdiameter.client.api.IMessage;
+import org.jdiameter.client.api.IRequest;
+import org.jdiameter.client.api.controller.IPeer;
+import org.jdiameter.client.api.controller.IRealmTable;
+import org.jdiameter.client.api.fsm.EventTypes;
+import org.jdiameter.client.api.io.IConnectionListener;
+import org.jdiameter.client.api.io.TransportException;
+import org.jdiameter.client.impl.helpers.XMLConfiguration;
+import org.jdiameter.common.api.statistic.IStatistic;
+import org.jdiameter.common.api.statistic.IStatisticManager;
+import org.jdiameter.common.api.statistic.IStatisticRecord;
+import org.jdiameter.common.impl.controller.AbstractPeer;
+import org.jdiameter.common.impl.statistic.StatisticManagerImpl;
+import org.jdiameter.server.api.agent.IAgentConfiguration;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownServiceException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+/**
+ * Various testcases for Router implementations
+ *
+ * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
+ */
+public class TestRouter {
+
+    @Test
+    public void testWeightedRoundRobin() throws Exception {
+
+        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
+        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
+
+        IStatisticManager manager = new StatisticManagerImpl(config);
+        PeerTest p1 = new PeerTest(1, 1, true, manager);
+        PeerTest p2 = new PeerTest(2, 1, true, manager);
+        PeerTest p3 = new PeerTest(3, 1, true, manager);
+        PeerTest p4 = new PeerTest(4, 1, true, manager);
+
+        List<IPeer> peers = new ArrayList<IPeer>(3);
+        peers.add(p1);
+        peers.add(p2);
+        peers.add(p3);
+
+        // Test simple round robin (all weight = 1)
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test weighted round robin (p1=2, p2=1, p3=1)
+        p1.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test weighted round robin (p1=2, p2=2, p3=1)
+        p2.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test equally weighted round robin (p1=2, p2=2, p3=2)
+        p3.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Add Peer-4 with weight 1 to list
+        peers.add(p4);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Next cycle would produce Peer-4, but reduce peer list now
+        peers = peers.subList(0,2); // now: Peer-1, Peer-2
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+    }
+
+    @Test
+    public void testWeightedLeastConnections() throws Exception {
+
+        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
+        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
+
+        IStatisticManager manager = new StatisticManagerImpl(config);
+        PeerTest p1 = new PeerTest(1, 1, true, manager);
+        PeerTest p2 = new PeerTest(2, 1, true, manager);
+        PeerTest p3 = new PeerTest(3, 1, true, manager);
+
+        List<IPeer> peers = new ArrayList<IPeer>(2);
+        peers.add(p1);
+        peers.add(p2);
+
+        // Test simple round robin (all weight = 1)
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // decrease p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 3
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase weight of p1
+        p1.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // decrease p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 2
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase weight and requests/s of p2
+        p2.setRating(2);
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+    }
+
+    private static class RealmTableTest implements IRealmTable {
+
+        public Realm matchRealm(IRequest request) {
+            return null;
+        }
+
+        public Realm matchRealm(IAnswer message, String destRealm) {
+            return null;
+        }
+
+        public Realm getRealm(String realmName, ApplicationId applicationId) {
+            return null;
+        }
+
+        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
+            return null;
+        }
+
+        public Collection<Realm> removeRealm(String realmName) {
+            return null;
+        }
+
+        public Collection<Realm> getRealms(String realm) {
+            return null;
+        }
+
+        public Collection<Realm> getRealms() {
+            return null;
+        }
+
+        public String getRealmForPeer(String fqdn) {
+            return null;
+        }
+
+        public void addLocalApplicationId(ApplicationId ap) {
+
+        }
+
+        public void removeLocalApplicationId(ApplicationId a) {
+
+        }
+
+        public void addLocalRealm(String localRealm, String fqdn) {
+
+        }
+
+        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
+            return null;
+        }
+
+        public Statistic getStatistic(String realmName) {
+            return null;
+        }
+
+        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
+            return null;
+        }
+
+        public boolean realmExists(String realmName) {
+            return false;
+        }
+
+        public boolean isWrapperFor(Class<?> iface) throws InternalException {
+            return false;
+        }
+
+        public <T> T unwrap(Class<T> iface) throws InternalException {
+            return null;
+        }
+    }
+
+    private static class PeerTest extends AbstractPeer implements IPeer {
+
+        private int id;
+        private int rating;
+        private boolean connected;
+
+        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
+            super(new URI("aaa://"+id), manager);
+            this.id = id;
+            this.rating = rating;
+            this.connected = connected;
+            createPeerStatistics();
+        }
+
+        public void setRating(int rating) {
+            this.rating = rating;
+        }
+
+        public int getRating() {
+            return rating;
+        }
+
+        public long getHopByHopIdentifier() {
+            return 0;
+        }
+
+        public void addMessage(IMessage message) {
+
+        }
+
+        public void remMessage(IMessage message) {
+
+        }
+
+        public IMessage[] remAllMessage() {
+            return new IMessage[0];
+        }
+
+        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
+            return false;
+        }
+
+        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
+            return false;
+        }
+
+        public boolean hasValidConnection() {
+            return connected;
+        }
+
+        public void setRealm(String realm) {
+
+        }
+
+        public void addStateChangeListener(StateChangeListener listener) {
+
+        }
+
+        public void remStateChangeListener(StateChangeListener listener) {
+
+        }
+
+        public void addConnectionListener(IConnectionListener listener) {
+
+        }
+
+        public void remConnectionListener(IConnectionListener listener) {
+
+        }
+
+        public IStatistic getStatistic() {
+            return statistic;
+        }
+
+        public boolean isConnected() {
+            return connected;
+        }
+
+        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
+
+        }
+
+        @Override
+        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
+
+        }
+
+        public <E> E getState(Class<E> enumc) {
+            return null;
+        }
+
+        public URI getUri() {
+            return uri;
+        }
+
+        public InetAddress[] getIPAddresses() {
+            return new InetAddress[0];
+        }
+
+        public String getRealmName() {
+            return null;
+        }
+
+        public long getVendorId() {
+            return 0;
+        }
+
+        public String getProductName() {
+            return null;
+        }
+
+        public long getFirmware() {
+            return 0;
+        }
+
+        public Set<ApplicationId> getCommonApplications() {
+            return null;
+        }
+
+        public void addPeerStateListener(PeerStateListener listener) {
+
+        }
+
+        public void removePeerStateListener(PeerStateListener listener) {
+
+        }
+
+        @Override
+        public String toString() {
+            return "Peer-"+id;
+        }
+    }
+
+}

--- a/core/jdiameter/impl/src/test/resources/jdiameter-weightedleastconnections-config.xml
+++ b/core/jdiameter/impl/src/test/resources/jdiameter-weightedleastconnections-config.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+
+<Configuration xmlns="http://www.jdiameter.org/jdiameter-client">
+
+    <!--
+    LocalPeer configuration
+
+    Each diameter node has a local peer that is e.g. announced during capability exchanges.
+    It also describes what diameter applications are provided by this particular stack.
+    -->
+    <LocalPeer>
+
+        <!-- Local IP description -->
+        <URI value="aaa://127.0.0.1:3868"/>
+        <IPAddress value="192.168.178.101"/>
+
+        <!-- Realm this client is assigned to -->
+        <Realm value="localpeer.2scale.net"/>
+
+        <!-- 2scale Vendor ID: 47420 -->
+        <VendorID value="47420"/>
+        <ProductName value="Test Diameter Stack"/>
+        <FirmwareRevision value="1"/>
+
+        <!-- Describes supported application IDs as client -->
+        <Applications>
+            <ApplicationID>
+                <VendorId value="10415"/>
+                <AuthApplId value="4"/>
+                <AcctApplId value="0"/>
+            </ApplicationID>
+        </Applications>
+    </LocalPeer>
+
+    <Parameters>
+        <!--
+        Determines whether the URI should be used as FQDN. If it is set to true, the stack expects
+        the destination/origin host to be in the format of "aaa://isdn.domain.com:3868" rather than the
+        normal "isdn.domain.com". The default value is false. -->
+        <UseUriAsFqdn value="true" /> <!-- Needed for Ericsson Emulator (set to true) -->
+
+        <!--
+        Determines how many tasks the peer state machine can have before rejecting the next task.
+        This queue contains FSM events and messaging.
+        -->
+        <QueueSize value="10000"/>
+
+        <!--
+        Determines the timeout for messages other than protocol FSM messages. The delay is in milliseconds.
+        -->
+        <MessageTimeOut value="60000"/>
+
+        <!--
+        Determines how long the stack waits for all resources to stop. The delays are in milliseconds.
+        -->
+        <StopTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for CER/CEA exchanges to timeout if there is no response.
+        The delays are in milliseconds.
+        -->
+        <CeaTimeOut value="10000"/>
+
+        <!--
+        Determines how long the stack waits to retry the communication with a peer that has stopped answering
+        DWR messages. The delay is in milliseconds.
+        -->
+        <IacTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DWR/DWA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DwaTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DPR/DPA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DpaTimeOut value="5000"/>
+
+        <!--
+        Determines how long it takes for the reconnection procedure to timeout. The delay is in milliseconds.
+        -->
+        <RecTimeOut value="10000"/>
+
+        <!-- Statistics Logger Configuration, required for proper balancing -->
+        <Statistics pause="5000" delay="5000" enabled="true" active_records="Peer,AppGenRequestPerSecond,NetGenRequestPerSecond"/>
+
+        <!--Concurrent>
+            <Entity name="ThreadGroup" size="64"/>
+            <Entity name="ProcessingMessageTimer" size="1"/>
+            <Entity name="DuplicationMessageTimer" size="1"/>
+            <Entity name="RedirectMessageTimer" size="1"/>
+            <Entity name="PeerOverloadTimer" size="1"/>
+            <Entity name="ConnectionTimer" size="1"/>
+            <Entity name="StatisticTimer" size="1"/>
+        </Concurrent-->
+
+    </Parameters>
+
+    <!--
+        The <Network> element contains elements that specify parameters for external peers.
+        The available elements and attributes are listed for reference.
+    -->
+    <Network>
+
+        <!--
+        Parent element containing the child element <Peer>, which specifies external peers and the way they connect
+        -->
+        <Peers>
+            <!--
+            <Peer> specifies the name of external peers, whether they should be treated as a server or client,
+            and what rating the peer has externally.
+            <Peer> supports the following properties:
+                name Specifies the name of the peer in the form of a URI.
+                     The structure is "aaa://[fqdn|ip]:port" (for example, "aaa://192.168.1.1:3868").
+                attempt_connect Determines if the stack should try to connect to this peer.
+                                This property accepts boolean values.
+                rating Specifies the rating of this peer in order to achieve peer priorities/sorting.
+            -->
+            <Peer name="aaa://127.0.0.1:13868" rating="1"/>
+            <Peer name="aaa://127.0.0.2:13868" rating="2"/>
+        </Peers>
+
+        <!--
+           Parent element containing the child element <Realm>, which specifies all realms that connect into the
+           Diameter network. <Realm> contains attributes and elements that describe different realms configured
+           for the Core. It supports <ApplicationID> child elements, which define the applications supported.
+        -->
+        <Realms>
+            <!--
+                <Realm> supports the following parameters:
+                peers
+                    Comma separated list of peers. Each peer is represented by an IP Address or FQDN.
+                local_action
+                    Determines the action the Local Peer will play on the specified realm: Act as a LOCAL peer.
+                dynamic
+                    Specifies if this realm is dynamic.
+                    That is, peers that connect to peers with this realm name will be added to the realm peer
+                    list if not present already.
+                exp_time
+                    The time before a peer belonging to this realm is removed if no connection is available.
+            -->
+            <Realm name="remotepeer.2scale.net" peers="127.0.0.1" local_action="LOCAL" dynamic="false" exp_time="1">
+                <ApplicationID>
+                    <VendorId value="10415" />
+                    <AuthApplId value="4" />
+                    <AcctApplId value="0" />
+                </ApplicationID>
+            </Realm>
+        </Realms>
+    </Network>
+
+    <Extensions>
+        <RouterEngine value="org.jdiameter.client.impl.router.WeightedLeastConnectionsRouter" />
+    </Extensions>
+
+</Configuration>

--- a/core/jdiameter/impl/src/test/resources/jdiameter-weightedroundrobin-config.xml
+++ b/core/jdiameter/impl/src/test/resources/jdiameter-weightedroundrobin-config.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0"?>
+
+<Configuration xmlns="http://www.jdiameter.org/jdiameter-client">
+
+    <!--
+    LocalPeer configuration
+
+    Each diameter node has a local peer that is e.g. announced during capability exchanges.
+    It also describes what diameter applications are provided by this particular stack.
+    -->
+    <LocalPeer>
+
+        <!-- Local IP description -->
+        <URI value="aaa://127.0.0.1:3868"/>
+        <IPAddress value="192.168.178.101"/>
+
+        <!-- Realm this client is assigned to -->
+        <Realm value="localpeer.2scale.net"/>
+
+        <!-- 2scale Vendor ID: 47420 -->
+        <VendorID value="47420"/>
+        <ProductName value="Test Diameter Stack"/>
+        <FirmwareRevision value="1"/>
+
+        <!-- Describes supported application IDs as client -->
+        <Applications>
+            <ApplicationID>
+                <VendorId value="10415"/>
+                <AuthApplId value="4"/>
+                <AcctApplId value="0"/>
+            </ApplicationID>
+        </Applications>
+    </LocalPeer>
+
+    <Parameters>
+        <!--
+        Determines whether the URI should be used as FQDN. If it is set to true, the stack expects
+        the destination/origin host to be in the format of "aaa://isdn.domain.com:3868" rather than the
+        normal "isdn.domain.com". The default value is false. -->
+        <UseUriAsFqdn value="true" /> <!-- Needed for Ericsson Emulator (set to true) -->
+
+        <!--
+        Determines how many tasks the peer state machine can have before rejecting the next task.
+        This queue contains FSM events and messaging.
+        -->
+        <QueueSize value="10000"/>
+
+        <!--
+        Determines the timeout for messages other than protocol FSM messages. The delay is in milliseconds.
+        -->
+        <MessageTimeOut value="60000"/>
+
+        <!--
+        Determines how long the stack waits for all resources to stop. The delays are in milliseconds.
+        -->
+        <StopTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for CER/CEA exchanges to timeout if there is no response.
+        The delays are in milliseconds.
+        -->
+        <CeaTimeOut value="10000"/>
+
+        <!--
+        Determines how long the stack waits to retry the communication with a peer that has stopped answering
+        DWR messages. The delay is in milliseconds.
+        -->
+        <IacTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DWR/DWA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DwaTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DPR/DPA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DpaTimeOut value="5000"/>
+
+        <!--
+        Determines how long it takes for the reconnection procedure to timeout. The delay is in milliseconds.
+        -->
+        <RecTimeOut value="10000"/>
+
+        <!-- Statistics Logger Configuration -->
+        <Statistics pause="5000" delay="5000" enabled="true"
+                    active_records="Concurrent,ScheduledExecService,Network,ScheduledExecService,AppGenRequestPerSecond,NetGenRequestPerSecond,Peer,Peer.local,PeerFSM"/>
+
+        <!--Concurrent>
+            <Entity name="ThreadGroup" size="64"/>
+            <Entity name="ProcessingMessageTimer" size="1"/>
+            <Entity name="DuplicationMessageTimer" size="1"/>
+            <Entity name="RedirectMessageTimer" size="1"/>
+            <Entity name="PeerOverloadTimer" size="1"/>
+            <Entity name="ConnectionTimer" size="1"/>
+            <Entity name="StatisticTimer" size="1"/>
+        </Concurrent-->
+
+    </Parameters>
+
+    <!--
+        The <Network> element contains elements that specify parameters for external peers.
+        The available elements and attributes are listed for reference.
+    -->
+    <Network>
+
+        <!--
+        Parent element containing the child element <Peer>, which specifies external peers and the way they connect
+        -->
+        <Peers>
+            <!--
+            <Peer> specifies the name of external peers, whether they should be treated as a server or client,
+            and what rating the peer has externally.
+            <Peer> supports the following properties:
+                name Specifies the name of the peer in the form of a URI.
+                     The structure is "aaa://[fqdn|ip]:port" (for example, "aaa://192.168.1.1:3868").
+                attempt_connect Determines if the stack should try to connect to this peer.
+                                This property accepts boolean values.
+                rating Specifies the rating of this peer in order to achieve peer priorities/sorting.
+            -->
+            <Peer name="aaa://127.0.0.1:13868" rating="1"/>
+            <Peer name="aaa://127.0.0.2:13868" rating="2"/>
+        </Peers>
+
+        <!--
+           Parent element containing the child element <Realm>, which specifies all realms that connect into the
+           Diameter network. <Realm> contains attributes and elements that describe different realms configured
+           for the Core. It supports <ApplicationID> child elements, which define the applications supported.
+        -->
+        <Realms>
+            <!--
+                <Realm> supports the following parameters:
+                peers
+                    Comma separated list of peers. Each peer is represented by an IP Address or FQDN.
+                local_action
+                    Determines the action the Local Peer will play on the specified realm: Act as a LOCAL peer.
+                dynamic
+                    Specifies if this realm is dynamic.
+                    That is, peers that connect to peers with this realm name will be added to the realm peer
+                    list if not present already.
+                exp_time
+                    The time before a peer belonging to this realm is removed if no connection is available.
+            -->
+            <Realm name="remotepeer.2scale.net" peers="127.0.0.1" local_action="LOCAL" dynamic="false" exp_time="1">
+                <ApplicationID>
+                    <VendorId value="10415" />
+                    <AuthApplId value="4" />
+                    <AcctApplId value="0" />
+                </ApplicationID>
+            </Realm>
+        </Realms>
+    </Network>
+
+    <Extensions>
+        <RouterEngine value="org.jdiameter.client.impl.router.WeightedRoundRobinRouter" />
+    </Extensions>
+
+</Configuration>


### PR DESCRIPTION
Issue #36: Implemented simple balancing mechanisms based upon the weighted round-robin and weighted least-connections strategies. Weighted least-connections is based on the statistics module and utilizes AppGenRequestPerSecond+NetGenRequestPerSecond. It would be worth actually counting the pending requests in a separate statistic record. 