### PR TITLE
netty reduce unneccessary threads #47

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/netty/TCPTransportClient.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/tcp/netty/TCPTransportClient.java
@@ -45,7 +45,7 @@ import io.netty.util.concurrent.EventExecutorGroup;
  */
 public class TCPTransportClient {
   protected EventLoopGroup workerGroup;
-  protected EventExecutorGroup eventExecutorGroup = new DefaultEventExecutorGroup(4);
+  protected EventExecutorGroup eventExecutorGroup = new DefaultEventExecutorGroup(1);
   protected Channel channel;
   protected TCPClientConnection parentConnection;
   protected InetSocketAddress destAddress;


### PR DESCRIPTION
- Use following VM arg for jdiameter charging server: -Dio.netty.allocator.type=pooled
- Keep seagull client's call-timeout-ms to a reasonable value (machine dependent) e.g. 5 sec 
`<define entity="traffic-param" name="call-timeout-ms" value="5000"></define>`
- Tune traffic-param also 
`<define entity="traffic-param" name="max-simultaneous-calls" value="20000"></define>`
