### PR TITLE
Change of Location-Estimate AVP type to "OctetString". Issue #62.

### DIFF
--- a/core/mux/common/config/dictionary.xml
+++ b/core/mux/common/config/dictionary.xml
@@ -2978,7 +2978,7 @@
   </avpdefn>
 
   <avpdefn name="Location-Estimate" code="1242" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >
-    <type type-name="UTF8String" />
+    <type type-name="OctetString" />
   </avpdefn>
 
   <avpdefn name="Positioning-Data" code="1245" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >

--- a/core/mux/common/config/dictionary.xml
+++ b/core/mux/common/config/dictionary.xml
@@ -2978,7 +2978,7 @@
   </avpdefn>
 
   <avpdefn name="Location-Estimate" code="1242" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >
-    <type type-name="OctetString" />
+    <type type-name="OctetString" /> <!-- changed from UTF8String (Rel 7) to OctetString as for 3GPP TS 32.299 (last release: 14.1.0)-->
   </avpdefn>
 
   <avpdefn name="Positioning-Data" code="1245" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >

--- a/testsuite/tests/src/test/resources/dictionary.xml
+++ b/testsuite/tests/src/test/resources/dictionary.xml
@@ -2978,7 +2978,7 @@
   </avpdefn>
 
   <avpdefn name="Location-Estimate" code="1242" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >
-    <type type-name="UTF8String" />
+    <type type-name="OctetString" />
   </avpdefn>
 
   <avpdefn name="Positioning-Data" code="1245" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >

--- a/testsuite/tests/src/test/resources/dictionary.xml
+++ b/testsuite/tests/src/test/resources/dictionary.xml
@@ -2978,7 +2978,7 @@
   </avpdefn>
 
   <avpdefn name="Location-Estimate" code="1242" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >
-    <type type-name="OctetString" />
+    <type type-name="OctetString" /> <!-- changed from UTF8String (Rel 7) to OctetString as for 3GPP TS 32.299 (last release: 14.1.0)-->
   </avpdefn>
 
   <avpdefn name="Positioning-Data" code="1245" vendor-id="TGPP" mandatory="must" protected="may" may-encrypt="no" vendor-bit="must" >


### PR DESCRIPTION
Hi @brainslog, it seems you don't use Location-Estimate AVP anywhere, so only change would be in the definition of the type.
