### PR TITLE
issue-51: Extend AVP dictionary, exposing original type

### DIFF
--- a/core/jdiameter/api/src/main/java/org/jdiameter/api/validation/AvpRepresentation.java
+++ b/core/jdiameter/api/src/main/java/org/jdiameter/api/validation/AvpRepresentation.java
@@ -175,6 +175,8 @@ public interface AvpRepresentation {
 
   int getRuleVendorBitAsInt();
 
+  String getOriginalType();
+
   String getType();
 
   boolean isProtected();

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/common/impl/validation/AvpRepresentationImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/common/impl/validation/AvpRepresentationImpl.java
@@ -68,6 +68,7 @@ public class AvpRepresentationImpl implements AvpRepresentation {
   protected String ruleMandatory;
   protected String ruleProtected;
   protected String ruleVendorBit;
+  protected String originalType;
   protected String type; // String, in case user defines his own type
 
   // Usually this will be -1, as only SessionId has fixed position
@@ -100,6 +101,7 @@ public class AvpRepresentationImpl implements AvpRepresentation {
     this.ruleMandatory = clone.ruleMandatory;
     this.ruleProtected = clone.ruleProtected;
     this.ruleVendorBit = clone.ruleVendorBit;
+    this.originalType = clone.originalType;
     this.type = clone.type;
     if (this.multiplicityIndicator.equals(_MP_NOT_ALLOWED)) {
       this.allowed = false;
@@ -176,7 +178,7 @@ public class AvpRepresentationImpl implements AvpRepresentation {
   }
 
   public AvpRepresentationImpl(String name, String description, int code, boolean mayEncrypt, String ruleMandatory, String ruleProtected,
-      String ruleVendorBit, long vendorId, String type) {
+      String ruleVendorBit, long vendorId, String originalType, String type) {
 
     // zero and more, since its definition.
     this(-1, code, vendorId, _MP_ZERO_OR_MORE, name);
@@ -198,6 +200,7 @@ public class AvpRepresentationImpl implements AvpRepresentation {
       this.ruleVendorBit = _DEFAULT_VENDOR;
     }
 
+    this.originalType = originalType;
     this.type = type;
     this._mandatory = this.ruleMandatory.equals("must");
     this._protected = this.ruleProtected.equals("must");
@@ -410,6 +413,11 @@ public class AvpRepresentationImpl implements AvpRepresentation {
   }
 
   @Override
+  public String getOriginalType() {
+    return originalType;
+  }
+
+  @Override
   public String getType() {
     return type;
   }
@@ -531,6 +539,7 @@ public class AvpRepresentationImpl implements AvpRepresentation {
     clone.ruleMandatory = this.ruleMandatory;
     clone.ruleProtected = this.ruleProtected;
     clone.ruleVendorBit = this.ruleVendorBit;
+    clone.originalType = this.originalType;
     clone.type = this.type;
 
     List<AvpRepresentation> cloneChildren = new ArrayList<AvpRepresentation>();

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/common/impl/validation/DictionaryImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/common/impl/validation/DictionaryImpl.java
@@ -331,7 +331,8 @@ public class DictionaryImpl implements Dictionary {
       // <grouped> <avp name="PoC-Change-Time" multiplicity="1" /> ... </grouped>
       //  OR
       // <type type-name="Enumerated"> <enum code="0" name="MULTICAST" /> ... </enumerated>
-      String avpType = UNDEFINED_AVP_TYPE;
+      String avpOriginalType = UNDEFINED_AVP_TYPE;
+      String avpType = avpOriginalType;
       List<AvpRepresentation> groupedAvpChilds = new ArrayList<AvpRepresentation>();
 
       NodeList avpDefnChildNodes = avpNode.getChildNodes();
@@ -342,7 +343,8 @@ public class DictionaryImpl implements Dictionary {
           Element avpDefnChildElement = (Element) avpDefnChildNode;
 
           if (avpDefnChildElement.getNodeName().equals("grouped")) {
-            avpType = "Grouped";
+            avpOriginalType = "Grouped";
+            avpType = avpOriginalType;
 
             // Let's fetch the childs
             // Format: <avp name="PoC-Change-Time" multiplicity="1" />
@@ -403,7 +405,8 @@ public class DictionaryImpl implements Dictionary {
             }
           }
           else if (avpDefnChildElement.getNodeName().equals("type")) {
-            avpType = avpDefnChildElement.getAttribute("type-name");
+            avpOriginalType = avpDefnChildElement.getAttribute("type-name");
+            avpType = avpOriginalType;
             //FIXME: baranowb: why this is like that? This changes type of AVP to primitive ONE..? Checks against type dont make sense, ie to check for Address type...
             avpType = typedefMap.get(avpType);
 
@@ -422,7 +425,7 @@ public class DictionaryImpl implements Dictionary {
         AvpRepresentationImpl avp = null;
 
         avp = new AvpRepresentationImpl(avpName, "N/A", Integer.valueOf(avpCode), avpMayEncrypt.equals("yes"), avpMandatory,
-            avpProtected, avpVendorBit, vendorCode, avpType);
+            avpProtected, avpVendorBit, vendorCode, avpOriginalType, avpType);
 
         if (avp.isGrouped()) {
           avp.setChildren(groupedAvpChilds);
@@ -454,7 +457,8 @@ public class DictionaryImpl implements Dictionary {
           logger.debug(new StringBuffer("[ERROR] Failed Parsing AVP: Name[").append(avpName).append("] Description[").append("N/A").
               append("] Code[").append(avpCode).append("] May-Encrypt[").append(avpMayEncrypt).append("] Mandatory[").append(avpMandatory).
               append("] Protected [").append(avpProtected).append("] Vendor-Bit [").append(avpVendorBit).append("] Vendor-Id [").append(avpVendorId).
-              append("] Constrained[").append("N/A").append("] Type [").append(avpType).append("]").toString(), e);
+              append("] Constrained[").append("N/A").append("] OriginalType [").append(avpOriginalType).
+              append("] Type [").append(avpType).append("]").toString(), e);
         }
       }
     }


### PR DESCRIPTION
Please take a loot at my sample implementation.
This helps me to get original type without changing provided XML dictionary.