### PR TITLE
Fix hang when decodeAvpSet receives vendorId=0

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/parser/ElementParser.java
@@ -286,11 +286,13 @@ public class ElementParser implements IElementParser {
         throw new AvpDataException("Not enough data in buffer!");
       }
       long vendor = 0;
+      boolean hasVendor = false;
       if ((flags & 0x80) != 0) {
         vendor = in.readInt();
+        hasVendor = true;
       }
       // Determine body L = length - 4(code) -1(flags) -3(length) [-4(vendor)]
-      byte[] rawData = new byte[length - (8 + (vendor == 0 ? 0 : 4))];
+      byte[] rawData = new byte[length - (8 + (hasVendor ? 4 : 0))];
       in.read(rawData);
       // skip remaining.
       // TODO: Do we need to padd everything? Or on send stack should properly fill byte[] ... ?


### PR DESCRIPTION
I added a boolean variable to control the presence of vendor-id AVP, even if it is vendorId = 0.

Closes #86 