### PR TITLE
Fix parseDictionary in order to load the file or InputStream passed b…

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/DictionarySingleton.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/DictionarySingleton.java
@@ -22,6 +22,8 @@
 
 package org.jdiameter.client.impl;
 
+import java.io.InputStream;
+
 import org.jdiameter.api.InternalException;
 import org.jdiameter.api.validation.Dictionary;
 import org.jdiameter.api.validation.ValidatorLevel;
@@ -36,22 +38,28 @@ import org.jdiameter.common.impl.validation.DictionaryImpl;
  */
 public class DictionarySingleton {
 
-  private static Dictionary SINGLETON = DictionaryImpl.INSTANCE; // default
-
   private DictionarySingleton() {
     // defeat instantiation
   }
 
   public static Dictionary getDictionary() {
-    return SINGLETON;
+    return DictionaryImpl.getInstance((String) null);
+  }
+
+  public static Dictionary getDictionary(String confFile) {
+    return DictionaryImpl.getInstance(confFile);
+  }
+
+  public static Dictionary getDictionary(InputStream is) {
+    return DictionaryImpl.getInstance(is);
   }
 
   static void init(String clazz, boolean validatorEnabled, ValidatorLevel validatorSendLevel, ValidatorLevel validatorReceiveLevel) throws InternalException {
     try {
-      SINGLETON = (Dictionary) Class.forName(clazz).getField("INSTANCE").get(null);
-      SINGLETON.setEnabled(validatorEnabled);
-      SINGLETON.setSendLevel(validatorSendLevel);
-      SINGLETON.setReceiveLevel(validatorReceiveLevel);
+      Class.forName(clazz).getMethod("getInstance", String.class).invoke(null, new Object[] {null});
+      DictionaryImpl.INSTANCE.setEnabled(validatorEnabled);
+      DictionaryImpl.INSTANCE.setSendLevel(validatorSendLevel);
+      DictionaryImpl.INSTANCE.setReceiveLevel(validatorReceiveLevel);
     }
     catch (Exception e) {
       throw new InternalException(e);

--- a/core/mux/jar/src/main/java/org/mobicents/diameter/dictionary/AvpDictionary.java
+++ b/core/mux/jar/src/main/java/org/mobicents/diameter/dictionary/AvpDictionary.java
@@ -74,13 +74,7 @@ public class AvpDictionary {
 
   private HashMap<AvpRepresentation, AvpRepresentation> avpMap = new HashMap<AvpRepresentation, AvpRepresentation>();
 
-  private Map<String, AvpRepresentation> nameToCodeMap = new TreeMap<String, AvpRepresentation>(new Comparator<String>() {
-
-    @Override
-    public int compare(String o1, String o2) {
-      return (o1 == null) ? 1 : (o2 == null) ? -1 : o1.compareTo(o2);
-    }
-  });
+  private Map<String, AvpRepresentation> nameToCodeMap = new HashMap<String, AvpRepresentation>();
 
   private AvpDictionary() {
     // Exists only to defeat instantiation.
@@ -105,16 +99,14 @@ public class AvpDictionary {
 
   public void parseDictionary(InputStream is) throws Exception {
     // we override default conf here.
-    this.stackDictionary = (DictionaryImpl) DictionarySingleton.getDictionary();
+    this.stackDictionary = (DictionaryImpl) DictionarySingleton.getDictionary(is);
     this.avpMap.clear();
     this.nameToCodeMap.clear();
 
     //dont like that....
     // fill AVP Map
-    Map<org.jdiameter.api.validation.AvpRepresentation, org.jdiameter.api.validation.AvpRepresentation> map = this.stackDictionary.getAvpMap();
-    for (org.jdiameter.api.validation.AvpRepresentation key:map.keySet()) {
-      AvpRepresentationImpl value = (AvpRepresentationImpl) map.get(key);
-      AvpRepresentation avp = new AvpRepresentation(value);
+    for (org.jdiameter.api.validation.AvpRepresentation value:this.stackDictionary.getAvpMap().values()) {
+      AvpRepresentation avp = new AvpRepresentation((AvpRepresentationImpl) value);
       this.avpMap.put(avp, avp);
       this.nameToCodeMap.put(avp.getName(), avp);
     }


### PR DESCRIPTION
…y argument

2 new APIs (getInstance(String confFile) and getDictionary(InputStream is)) where created on DictionaryImpl and DictionarySingleton;
Previous behaviour was maintained and its available using parseDictionary((InputStream) null)
ParseDictionary API was changed and nameToCodeMap TreeMap was converted in HashMap to improve performance