### PR TITLE
All core jDiameter classes now use the slf4j facade exclusively.

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/agent/ProxyAgentImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/agent/ProxyAgentImpl.java
@@ -42,7 +42,6 @@
 
 package org.jdiameter.server.impl.agent;
 
-import org.apache.log4j.Logger;
 import org.jdiameter.api.Answer;
 import org.jdiameter.api.Request;
 import org.jdiameter.client.api.IContainer;
@@ -50,6 +49,8 @@ import org.jdiameter.client.api.IRequest;
 import org.jdiameter.client.api.controller.IRealm;
 import org.jdiameter.client.api.controller.IRealmTable;
 import org.jdiameter.server.api.agent.IProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -58,7 +59,7 @@ import org.jdiameter.server.api.agent.IProxy;
  */
 public class ProxyAgentImpl extends AgentImpl implements IProxy {
 
-  private static Logger logger = Logger.getLogger(ProxyAgentImpl.class);
+  private static Logger logger = LoggerFactory.getLogger(ProxyAgentImpl.class);
 
   /**
    * @param container

--- a/core/mux/jar/src/main/java/org/mobicents/diameter/dictionary/AvpDictionary.java
+++ b/core/mux/jar/src/main/java/org/mobicents/diameter/dictionary/AvpDictionary.java
@@ -45,15 +45,14 @@ package org.mobicents.diameter.dictionary;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
-import org.apache.log4j.Logger;
 import org.jdiameter.client.impl.DictionarySingleton;
 import org.jdiameter.common.impl.validation.AvpRepresentationImpl;
 import org.jdiameter.common.impl.validation.DictionaryImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  *
@@ -65,7 +64,7 @@ import org.jdiameter.common.impl.validation.DictionaryImpl;
  */
 public class AvpDictionary {
 
-  private static transient Logger logger = Logger.getLogger(AvpDictionary.class);
+  private static transient Logger logger = LoggerFactory.getLogger(AvpDictionary.class);
 
   public static final AvpDictionary INSTANCE = new AvpDictionary();
 


### PR DESCRIPTION
resolves #145 