### PR TITLE
Fixes Restcomm#150 : Resubmissions of requests to alternate peers now possible until all peers exhausted, while respecting Weighted Round Robin balancing algorithm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .classpath
 .project
 .settings
+.checkstyle
 
 # IntelliJ IDEA #
 #################
@@ -29,3 +30,7 @@ target
 Icon?
 ehthumbs.db
 Thumbs.db
+
+# Testsuite generated *_sctp.xml files #
+########################################
+testsuite/tests/*_sctp.xml

--- a/.project
+++ b/.project
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-  <name>diameter-parent</name>
-  <comment/>
-  <projects/>
-  <buildSpec>
-    <buildCommand>
-      <name>org.eclipse.jdt.core.javabuilder</name>
-      <arguments/>
-    </buildCommand>
-  </buildSpec>
-  <natures>
-    <nature>org.eclipse.jdt.core.javanature</nature>
-  </natures>
+	<name>diameter-parent</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
 </projectDescription>

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
@@ -121,6 +121,15 @@ public interface IRouter  {
    */
   void processRedirectAnswer(IRequest request, IAnswer answer, IPeerTable table) throws InternalException, RouteException;
 
+
+  /**
+   * Called when 3004 is received for request. This method update cc-request-number and sends the message back to stack.
+   * @param request
+   * @param table
+   */
+  void processSecondAttempt(IRequest request, IPeerTable table) throws InternalException, RouteException;
+
+
   /**
    * Based on Redirect entries or any other factors, this method changes route information.
    * @param message
@@ -128,6 +137,8 @@ public interface IRouter  {
    * @throws RouteException
    * @throws AvpDataException
    */
+
+
   boolean updateRoute(IRequest message) throws RouteException, AvpDataException;
 
 }

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
@@ -123,8 +123,22 @@ public interface IRouter  {
 
 
   /**
-   * Called when a 3002 or 3004 is received for a request. This method updates cc-request-number and attempts to resubmit the request
-   * to an alternative peer.
+   * Indicates whether this router implementation is able to resubmit requests to an alternative peer,
+   * for which a Busy or Unable to Deliver Answer has already been received from one peer.<br /><br />
+   *
+   * <strong>Note: </strong> Returning <code>true</code> from this method when the router implementation has not been designed to
+   * handle resubmitting such requests can result in a request being resubmitted perpetually.
+   *
+   * @return <code>false</code> by default. <code>true</code> when and only when the router implementation has specific logic to handle
+   * submitting requests which have received a Busy or Unable to Deliver Answer from one peer, to an alternative peer, and to avoid
+   * perpetual re-submission of such requests.
+   */
+  boolean canProcessBusyOrUnableToDeliverAnswer();
+
+
+  /**
+   * Called when a 3002 or 3004 is received for a request. This method attempts to resubmit the request to an alternative peer.
+   *
    * @param request
    * @param table
    */

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/api/router/IRouter.java
@@ -123,11 +123,12 @@ public interface IRouter  {
 
 
   /**
-   * Called when 3004 is received for request. This method update cc-request-number and sends the message back to stack.
+   * Called when a 3002 or 3004 is received for a request. This method updates cc-request-number and attempts to resubmit the request
+   * to an alternative peer.
    * @param request
    * @param table
    */
-  void processSecondAttempt(IRequest request, IPeerTable table) throws InternalException, RouteException;
+  void processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) throws InternalException, RouteException;
 
 
   /**

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/controller/PeerImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/controller/PeerImpl.java
@@ -493,7 +493,6 @@ public class PeerImpl extends AbstractPeer implements IPeer {
 
   private IMessage processBusyOrUnableToDeliverAnswer(IMessage request, IMessage answer) {
     try {
-      incrementRequestNumber(request);
       router.processBusyOrUnableToDeliverAnswer(request, table);
       return null;
     }
@@ -505,14 +504,6 @@ public class PeerImpl extends AbstractPeer implements IPeer {
       }
     }
     return answer;
-  }
-
-  private void incrementRequestNumber(IMessage request) throws AvpDataException {
-    int requestNumber = request.getAvps().getAvp(Avp.CC_REQUEST_NUMBER).getInteger32();
-    requestNumber++;
-    logger.trace("Incremented requestNumber to [{}] ", requestNumber);
-    request.getAvps().removeAvp(Avp.CC_REQUEST_NUMBER);
-    request.getAvps().addAvp(Avp.CC_REQUEST_NUMBER, requestNumber);
   }
 
   @Override

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/controller/PeerImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/controller/PeerImpl.java
@@ -1060,10 +1060,9 @@ public class PeerImpl extends AbstractPeer implements IPeer {
           if (isRedirectAnswer(avpResCode, message)) {
             message.setListener(request.getEventListener());
             message = processRedirectAnswer(request, message);
-            //if return value is not null, there was some error, lets try to invoke listener if it exists...
+            // if return value is not null, there was some error, lets try to invoke listener if it exists...
             isProcessed = message == null;
           }
-          avpResCode = message.getAvps().getAvp(RESULT_CODE);
           if (isBusyOrUnableToDeliverAnswer(avpResCode, message)) {
             message = processBusyOrUnableToDeliverAnswer(request, message);
             // if return value is not null, there was some error, lets try to invoke listener if it exists...

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
@@ -507,7 +507,7 @@ public class RouterImpl implements IRouter {
       }
 
       // Balancing
-      IPeer peer = selectPeer(availablePeers);
+      IPeer peer = selectPeer(message, availablePeers);
       if (peer == null) {
         throw new RouteException("Unable to find valid connection to peer[" + destHost + "] in realm[" + destRealm + "]");
       }
@@ -626,6 +626,21 @@ public class RouterImpl implements IRouter {
         }
       }
       //now send
+      table.sendMessage((IMessage) request);
+    }
+    catch (AvpDataException exc) {
+      throw new InternalException(exc);
+    }
+    catch (IllegalDiameterStateException e) {
+      throw new InternalException(e);
+    }
+    catch (IOException e) {
+      throw new InternalException(e);
+    }
+  }
+
+  public void processSecondAttempt(IRequest request, IPeerTable table) throws InternalException, RouteException {
+    try {
       table.sendMessage((IMessage) request);
     }
     catch (AvpDataException exc) {
@@ -787,7 +802,7 @@ public class RouterImpl implements IRouter {
     requestEntryMap = null;
   }
 
-  protected IPeer selectPeer(List<IPeer> availablePeers) {
+  protected IPeer selectPeer(IMessage message, List<IPeer> availablePeers) {
     IPeer p = null;
     for (IPeer c : availablePeers) {
       if (p == null || c.getRating() >= p.getRating()) {

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
@@ -639,7 +639,7 @@ public class RouterImpl implements IRouter {
     }
   }
 
-  public void processSecondAttempt(IRequest request, IPeerTable table) throws InternalException, RouteException {
+  public void processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) throws InternalException, RouteException {
     try {
       table.sendMessage((IMessage) request);
     }
@@ -802,7 +802,7 @@ public class RouterImpl implements IRouter {
     requestEntryMap = null;
   }
 
-  protected IPeer selectPeer(IMessage message, List<IPeer> availablePeers) {
+  protected IPeer selectPeer(List<IPeer> availablePeers) {
     IPeer p = null;
     for (IPeer c : availablePeers) {
       if (p == null || c.getRating() >= p.getRating()) {
@@ -810,6 +810,10 @@ public class RouterImpl implements IRouter {
       }
     }
     return p;
+  }
+
+  protected IPeer selectPeer(IMessage message, List<IPeer> availablePeers) {
+    return selectPeer(availablePeers);
   }
 
   //    protected void redirectProcessing(IMessage message, final String destRealm, final String destHost) throws AvpDataException {

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/RouterImpl.java
@@ -639,6 +639,18 @@ public class RouterImpl implements IRouter {
     }
   }
 
+  /**
+   * This method should always return false unless specifically designed to handle
+   * submitting requests which have received a Busy or Unable to Deliver Answer from one peer, to an alternative peer, and to avoid
+   * perpetual re-submission of such requests.
+   *
+   * @return <code>false</code>
+   */
+  @Override
+  public boolean canProcessBusyOrUnableToDeliverAnswer() {
+    return false;
+  }
+
   public void processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) throws InternalException, RouteException {
     try {
       table.sendMessage((IMessage) request);

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
@@ -22,7 +22,9 @@ package org.jdiameter.client.impl.router;
 import org.jdiameter.api.Configuration;
 import org.jdiameter.api.MetaData;
 import org.jdiameter.api.PeerState;
+import org.jdiameter.api.StatisticRecord;
 import org.jdiameter.client.api.IContainer;
+import org.jdiameter.client.api.IMessage;
 import org.jdiameter.client.api.controller.IPeer;
 import org.jdiameter.client.api.controller.IRealmTable;
 import org.jdiameter.common.api.concurrent.IConcurrentFactory;
@@ -124,7 +126,7 @@ public class WeightedLeastConnectionsRouter extends RouterImpl implements IRoute
    * @return the selected peer according to algorithm
    */
   @Override
-  public IPeer selectPeer(List<IPeer> availablePeers) {
+  public IPeer selectPeer(IMessage message, List<IPeer> availablePeers) {
     int peerSize = availablePeers != null ? availablePeers.size() : 0;
 
     // Return none if empty, or first if only one member found
@@ -171,6 +173,16 @@ public class WeightedLeastConnectionsRouter extends RouterImpl implements IRoute
         logger.debug("Statistics for peer are disabled. Please enable statistics in client config");
       }
       return 0;
+    }
+
+//    logger.debug("peer.getUri() : " + peer.getUri());
+//    logger.debug("AppGenRequestPerSecond : " + getRecord(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+peer.getUri(), stats));
+//    logger.debug("NetGenRequestPerSecond : " + getRecord(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+peer.getUri(), stats));
+//    logger.debug("AppGenRejectedResponse : " + getRecord(IStatisticRecord.Counters.AppGenRejectedResponse.name()+'.'+peer.getUri(), stats));
+//    logger.debug("NetGenRejectedResponse : " + getRecord(IStatisticRecord.Counters.NetGenRejectedResponse.name()+'.'+peer.getUri(), stats));
+
+    for (StatisticRecord rec : stats.getRecords()){
+      logger.debug(rec.getName() + " : " + rec.getValueAsLong());
     }
 
     // Requests per second initiated by Local Peer + Request initiated by Remote peer

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedLeastConnectionsRouter.java
@@ -19,10 +19,12 @@
 
 package org.jdiameter.client.impl.router;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.jdiameter.api.Configuration;
 import org.jdiameter.api.MetaData;
 import org.jdiameter.api.PeerState;
-import org.jdiameter.api.StatisticRecord;
 import org.jdiameter.client.api.IContainer;
 import org.jdiameter.client.api.IMessage;
 import org.jdiameter.client.api.controller.IPeer;
@@ -30,12 +32,9 @@ import org.jdiameter.client.api.controller.IRealmTable;
 import org.jdiameter.common.api.concurrent.IConcurrentFactory;
 import org.jdiameter.common.api.statistic.IStatistic;
 import org.jdiameter.common.api.statistic.IStatisticRecord;
+import org.jdiameter.server.api.IRouter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Arrays;
-import java.util.List;
-import org.jdiameter.server.api.IRouter;
 
 /**
  * Weighted Least-Connections router implementation<br/><br/>
@@ -104,13 +103,13 @@ public class WeightedLeastConnectionsRouter extends RouterImpl implements IRoute
    * <pre>
    * {@code
    *   for (m = 0; m < n; m++) {
-   *   if (W(Sm) > 0) {
-   *     for (i = m+1; i < n; i++) {
-   *     if (C(Sm)*W(Si) > C(Si)*W(Sm))
-   *       m = i;
+   *     if (W(Sm) > 0) {
+   *       for (i = m+1; i < n; i++) {
+   *         if (C(Sm)*W(Si) > C(Si)*W(Sm))
+   *           m = i;
+   *       }
+   *       return Sm;
    *     }
-   *     return Sm;
-   *   }
    *   }
    *   return NULL;
    * }
@@ -124,6 +123,19 @@ public class WeightedLeastConnectionsRouter extends RouterImpl implements IRoute
    * @see <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Least-Connection_Scheduling</a>
    * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
    * @return the selected peer according to algorithm
+   */
+  @Override
+  public IPeer selectPeer(List<IPeer> availablePeers) {
+    return selectPeer(null, availablePeers);
+  }
+
+  /**
+   * Return peer with least connections
+   *
+   * @param message the message to be sent
+   * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
+   * @return the selected peer according to algorithm
+   *
    */
   @Override
   public IPeer selectPeer(IMessage message, List<IPeer> availablePeers) {
@@ -173,16 +185,6 @@ public class WeightedLeastConnectionsRouter extends RouterImpl implements IRoute
         logger.debug("Statistics for peer are disabled. Please enable statistics in client config");
       }
       return 0;
-    }
-
-//    logger.debug("peer.getUri() : " + peer.getUri());
-//    logger.debug("AppGenRequestPerSecond : " + getRecord(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+peer.getUri(), stats));
-//    logger.debug("NetGenRequestPerSecond : " + getRecord(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+peer.getUri(), stats));
-//    logger.debug("AppGenRejectedResponse : " + getRecord(IStatisticRecord.Counters.AppGenRejectedResponse.name()+'.'+peer.getUri(), stats));
-//    logger.debug("NetGenRejectedResponse : " + getRecord(IStatisticRecord.Counters.NetGenRejectedResponse.name()+'.'+peer.getUri(), stats));
-
-    for (StatisticRecord rec : stats.getRecords()){
-      logger.debug(rec.getName() + " : " + rec.getValueAsLong());
     }
 
     // Requests per second initiated by Local Peer + Request initiated by Remote peer

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedRoundRobinResubmittingRouter.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/router/WeightedRoundRobinResubmittingRouter.java
@@ -19,8 +19,6 @@
 
 package org.jdiameter.client.impl.router;
 
-import static org.jdiameter.api.Avp.CC_REQUEST_NUMBER;
-
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,7 +27,6 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.jdiameter.api.AvpDataException;
 import org.jdiameter.api.Configuration;
 import org.jdiameter.api.MetaData;
 import org.jdiameter.api.PeerState;
@@ -47,23 +44,25 @@ import org.slf4j.LoggerFactory;
  *
  * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
  * @see
- * <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
+ *      <a href=
+ *      "http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
  */
 public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements IRouter {
 
   private static final Logger logger = LoggerFactory.getLogger(WeightedRoundRobinResubmittingRouter.class);
 
+  private static final int ATTEMPTED_PEER_RETENTION_PERIOD_MS = 30000;
+
   private int lastSelectedPeer = -1;
   private int currentWeight = 0;
-  private Map<String, Set<IPeer>> attemptedPeers = new ConcurrentHashMap<String, Set<IPeer>>();
-  private int timeout = 30000;
+  private Map<MessageKey, Set<IPeer>> attemptedPeers = new ConcurrentHashMap<MessageKey, Set<IPeer>>();
 
   protected WeightedRoundRobinResubmittingRouter(IRealmTable table, Configuration config) {
     super(null, null, table, config, null);
   }
 
-  public WeightedRoundRobinResubmittingRouter(IContainer container, IConcurrentFactory concurrentFactory,
-                                  IRealmTable realmTable, Configuration config, MetaData aMetaData) {
+  public WeightedRoundRobinResubmittingRouter(IContainer container, IConcurrentFactory concurrentFactory, IRealmTable realmTable, Configuration config,
+      MetaData aMetaData) {
     super(container, concurrentFactory, realmTable, config, aMetaData);
   }
 
@@ -87,6 +86,7 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
    * max(S) is the maximum weight of all the servers in S;
    * gcd(S) is the greatest common divisor of all server weights in S;
    * <p>
+   *
    * <pre>
    * {@code
    *   while (true) {
@@ -129,10 +129,12 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
    * the balancing algorithm is disturbed and might be distributed uneven.
    * This is likely to happen if peers are flapping.
    *
-   * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
+   * @param availablePeers
+   *          list of peers that are in {@link PeerState#OKAY OKAY} state
    * @return the selected peer according to algorithm
    * @see
-   * <a href="http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
+   *      <a href=
+   *      "http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling">http://kb.linuxvirtualserver.org/wiki/Weighted_Round-Robin_Scheduling</a>
    */
   @Override
   public IPeer selectPeer(List<IPeer> availablePeers) {
@@ -146,10 +148,12 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
    * the same peer that responded with the Busy or Unable To Deliver Answer is not selected for
    * any subsequent submissions of the same request.
    *
-   * @param message The message to be re-attempted due to a Busy or Unable To Deliver Answer
-   * @param availablePeers list of peers that are in {@link PeerState#OKAY OKAY} state
+   * @param message
+   *          The message to be re-attempted due to a Busy or Unable To Deliver Answer
+   * @param availablePeers
+   *          list of peers that are in {@link PeerState#OKAY OKAY} state
    * @return the selected peer according to algorithm, ensuring that if the <code>message</code> is passed, that
-   * the same peer that responded with the Busy or Unable To Deliver Answer is not selected a second time
+   *         the same peer that responded with the Busy or Unable To Deliver Answer is not selected a second time
    *
    */
   @Override
@@ -157,28 +161,29 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
     IPeer selectedPeer = null;
     int peerSize = availablePeers != null ? availablePeers.size() : 0;
 
-    logger.debug("peerSize " + peerSize);
     // Return none if empty, or first if only one member found
     if (peerSize <= 0) {
       return null;
     }
 
-    if (message != null) {
-      if (message.getPeer() != null) {
-        addAttemptedPeer(message, message.getPeer());
+    if (message != null && message.getPeer() != null) {
+      addAttemptedPeer(message, message.getPeer());
+
+      long numberOfAttempts = 0;
+      MessageKey messageKey = getMessageKey(message);
+      Set<IPeer> peerSet = attemptedPeers.get(messageKey);
+      if (peerSet != null) {
+        numberOfAttempts = peerSet.size();
+      }
+      if (logger.isTraceEnabled()) {
+        logger.trace("Selecting subsequent peer for {} [numberOfAttempts={}]", messageKey, numberOfAttempts);
       }
 
-      long requestNumber = 0;
-      try {
-        requestNumber = message.getAvps().getAvp(CC_REQUEST_NUMBER).getUnsigned32();
-        logger.debug("Selecting subsequent peer for [sessionId={}, requestNumber={}]", message.getSessionId(), requestNumber);
-      }
-      catch (AvpDataException e) {
-        e.printStackTrace();
-      }
-
-      if (requestNumber == peerSize) {
-        logger.debug("All peers exhausted for message [sessionId={}], giving up...", message.getSessionId());
+      if (numberOfAttempts == peerSize) {
+        if (logger.isDebugEnabled()) {
+          logger.debug("All peers exhausted for {}, giving up...", messageKey);
+        }
+        removeAttemptedPeers(messageKey);
         return null;
       }
     }
@@ -193,12 +198,11 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
     for (IPeer peer : availablePeers) {
       maxWeight = Math.max(maxWeight, peer.getRating());
       gcd = (gcd == null) ? peer.getRating() : gcd(gcd, peer.getRating());
-      logger.debug("Peer [uri={}, realmName={}, rating={}]", peer.getUri(), peer.getRealmName(), peer.getRating());
     }
 
     // Find best matching candidate. Synchronized here due to consistent changes on member variables
     synchronized (this) {
-      for (; ; ) {
+      for (;;) {
         lastSelectedPeer = (lastSelectedPeer + 1) % peerSize;
         if (lastSelectedPeer == 0) {
           currentWeight = currentWeight - gcd;
@@ -212,77 +216,85 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
         }
         IPeer candidate = availablePeers.get(lastSelectedPeer);
         if (candidate.getRating() >= currentWeight) {
+          if (message != null && message.getPeer() != null) {
+            if (isPeerPreviouslyAttempted(lastSelectedPeer, availablePeers, message)) {
+              continue;
+            }
+          }
+
           selectedPeer = availablePeers.get(lastSelectedPeer);
-          if (message != null) {
-            if (message.getPeer() != null) {
-              logger.debug("Moving selected Peer [uri={}, realmName={}, rating={}] to next peer as it looks like to be a subsequent attempt of this message and last peer of this message", message.getPeer().getUri(), message.getPeer().getRealmName(), message.getPeer().getRating());
-              lastSelectedPeer = selectPeerForSubsequentSubmission(lastSelectedPeer, availablePeers, message);
-              if (lastSelectedPeer < 0) {
-                logger.debug("No unattempted peers left for message [sessionId={}], giving up...", message.getSessionId());
-                return null;
-              }
-              else {
-                selectedPeer = availablePeers.get(lastSelectedPeer);
-              }
-            } else logger.trace("message.getPeer() == null");
-          } else logger.trace("message != null");
-          logger.trace("Selected Peer [uri={}, realmName={}, rating={}]", selectedPeer.getUri(), selectedPeer.getRealmName(), selectedPeer.getRating());
+
+          if (logger.isTraceEnabled()) {
+            logger.trace("Selected Peer [uri={}, realmName={}, rating={}]", selectedPeer.getUri(), selectedPeer.getRealmName(), selectedPeer.getRating());
+          }
           return selectedPeer;
         }
       }
     }
   }
 
-  private int selectPeerForSubsequentSubmission(int selectedPeerIndex, List<IPeer> availablePeers, IMessage message) {
+  private MessageKey getMessageKey(final IMessage message) {
+    return new MessageKey(message.getSessionId(), message.getEndToEndIdentifier());
+  }
 
-    logger.debug("Checking peer history of message [sessionId={}] ", message.getSessionId());
-
-    if (!attemptedPeers.containsKey(message.getSessionId())) {
-      logger.debug("attemptedPeers does not contain selected peer so return it");
-      return selectedPeerIndex;
+  private boolean isPeerPreviouslyAttempted(int selectedPeerIndex, List<IPeer> availablePeers, IMessage message) {
+    boolean isPeerPreviouslyAttempted = false;
+    final MessageKey messageKey = getMessageKey(message);
+    if (logger.isTraceEnabled()) {
+      logger.trace("Checking whether selected Peer [id={}] has already had {} sent to it", selectedPeerIndex, messageKey);
     }
-    for (int i = 0; i < availablePeers.size(); i++) {
+
+    if (attemptedPeers.containsKey(messageKey)) {
       IPeer candidate = availablePeers.get(selectedPeerIndex);
-      if (attemptedPeers.get(message.getSessionId()).contains(candidate)) {
-        logger.debug("Peer [{}] has been tried before, skipping to next peer", candidate.getUri());
-        selectedPeerIndex = selectedPeerIndex < availablePeers.size() - 1 ? selectedPeerIndex + 1 : 0;
-        continue;
-      } else {
-        logger.debug("Peer [{}] hasn't been tried for message [sessionId={}]", candidate.getUri(), message.getSessionId());
-        return selectedPeerIndex;
+      if (attemptedPeers.get(messageKey).contains(candidate)) {
+        if (logger.isTraceEnabled()) {
+          logger.trace("Peer [uri={}, realmName={}, rating={}] has been tried before, try next peer", candidate.getUri(), candidate.getRealmName(),
+              candidate.getRating());
+        }
+        isPeerPreviouslyAttempted = true;
       }
     }
-    logger.debug("All peers have been tried, returning -1");
-    attemptedPeers.remove(message.getSessionId());
-    return -1;
+
+    return isPeerPreviouslyAttempted;
   }
 
   private synchronized void addAttemptedPeer(final IMessage message, IPeer peer) {
-    if (attemptedPeers.containsKey(message.getSessionId())) {
-      attemptedPeers.get(message.getSessionId()).add(peer);
-    } else {
+    final MessageKey messageKey = getMessageKey(message);
+    if (attemptedPeers.containsKey(messageKey)) {
+      attemptedPeers.get(messageKey).add(peer);
+    }
+    else {
       Set<IPeer> peerSet = new HashSet<IPeer>();
       peerSet.add(peer);
-      attemptedPeers.put(message.getSessionId(), peerSet);
+      attemptedPeers.put(messageKey, peerSet);
 
       new Timer().schedule(new TimerTask() {
         @Override
         public void run() {
-          removeAttemptedPeers(message.getSessionId());
+          removeAttemptedPeers(messageKey);
         }
-      }, timeout);
+      }, ATTEMPTED_PEER_RETENTION_PERIOD_MS);
     }
   }
 
-  void removeAttemptedPeers(String sessionId) {
-    logger.debug("Removing attemptedPeers for [sessionId={}] (currently [attemptedPeers.size()={}])  ", sessionId, attemptedPeers.size());
-    Set<IPeer> peerSet = attemptedPeers.remove(sessionId);
-    if (peerSet != null) {
-      logger.trace("peerSet with [size={}] has been removed for message [sessionId={}]" + peerSet.size(), sessionId);
-    } else {
-      logger.warn("No peers removed from attemptedPeers for [sessionId={}]!", sessionId);
+  private void removeAttemptedPeers(MessageKey messageKey) {
+    if (logger.isDebugEnabled()) {
+      logger.debug("Removing attemptedPeers for {} (currently [attemptedPeers.size()={}])  ", messageKey, attemptedPeers.size());
     }
-    logger.debug("Done removing attemptedPeers for [sessionId={}] (now [attemptedPeers.size()={}])  ", sessionId, attemptedPeers.size());
+    Set<IPeer> peerSet = attemptedPeers.remove(messageKey);
+    if (peerSet != null) {
+      if (logger.isTraceEnabled()) {
+        logger.trace("peerSet with [size={}] has been removed for {}", peerSet.size(), messageKey);
+      }
+    }
+    else {
+      if (logger.isWarnEnabled()) {
+        logger.warn("No peers removed from attemptedPeers for {}!", messageKey);
+      }
+    }
+    if (logger.isDebugEnabled()) {
+      logger.debug("Done removing attemptedPeers for {} (now [attemptedPeers.size()={}])  ", messageKey, attemptedPeers.size());
+    }
   }
 
   /**
@@ -295,5 +307,68 @@ public class WeightedRoundRobinResubmittingRouter extends RouterImpl implements 
    */
   protected int gcd(int a, int b) {
     return (b == 0) ? a : gcd(b, a % b);
+  }
+
+  /**
+   * Defines a class which can be used to uniquely define any single message within any given session.
+   *
+   */
+  private class MessageKey {
+    private String sessionId;
+    private long endToEndId;
+
+    MessageKey(String sessionId, long endToEndId) {
+      super();
+      this.sessionId = sessionId;
+      this.endToEndId = endToEndId;
+    }
+
+    @Override
+    public String toString() {
+      return "MessageKey [sessionId=" + sessionId + ", endToEndId=" + endToEndId + "]";
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + getOuterType().hashCode();
+      result = prime * result + (int) (endToEndId ^ (endToEndId >>> 32));
+      result = prime * result + ((sessionId == null) ? 0 : sessionId.hashCode());
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj == null) {
+        return false;
+      }
+      if (getClass() != obj.getClass()) {
+        return false;
+      }
+      MessageKey other = (MessageKey) obj;
+      if (!getOuterType().equals(other.getOuterType())) {
+        return false;
+      }
+      if (endToEndId != other.endToEndId) {
+        return false;
+      }
+      if (sessionId == null) {
+        if (other.sessionId != null) {
+          return false;
+        }
+      }
+      else if (!sessionId.equals(other.sessionId)) {
+        return false;
+      }
+      return true;
+    }
+
+    private WeightedRoundRobinResubmittingRouter getOuterType() {
+      return WeightedRoundRobinResubmittingRouter.this;
+    }
   }
 }

--- a/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
+++ b/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
@@ -78,6 +78,8 @@ public class TestRouter extends TestCase {
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
     WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
 
+    assertFalse(router.canProcessBusyOrUnableToDeliverAnswer());
+
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);
     PeerTest p2 = new PeerTest(2, 1, true, manager);
@@ -183,6 +185,8 @@ public class TestRouter extends TestCase {
 
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml");
     WeightedRoundRobinResubmittingRouter router = new WeightedRoundRobinResubmittingRouter(new RealmTableTest(), config);
+
+    assertTrue(router.canProcessBusyOrUnableToDeliverAnswer());
 
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);
@@ -290,6 +294,8 @@ public class TestRouter extends TestCase {
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml");
     WeightedRoundRobinResubmittingRouter router = new WeightedRoundRobinResubmittingRouter(new RealmTableTest(), config);
 
+    assertTrue(router.canProcessBusyOrUnableToDeliverAnswer());
+
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);
     PeerTest p2 = new PeerTest(2, 2, true, manager);
@@ -330,6 +336,8 @@ public class TestRouter extends TestCase {
 
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml");
     WeightedRoundRobinResubmittingRouter router = new WeightedRoundRobinResubmittingRouter(new RealmTableTest(), config);
+
+    assertTrue(router.canProcessBusyOrUnableToDeliverAnswer());
 
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);
@@ -375,6 +383,8 @@ public class TestRouter extends TestCase {
 
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml");
     WeightedRoundRobinResubmittingRouter router = new WeightedRoundRobinResubmittingRouter(new RealmTableTest(), config);
+
+    assertTrue(router.canProcessBusyOrUnableToDeliverAnswer());
 
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);
@@ -428,6 +438,8 @@ public class TestRouter extends TestCase {
 
     Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
     WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
+
+    assertFalse(router.canProcessBusyOrUnableToDeliverAnswer());
 
     IStatisticManager manager = new StatisticManagerImpl(config);
     PeerTest p1 = new PeerTest(1, 1, true, manager);

--- a/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
+++ b/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
@@ -1,454 +1,454 @@
-/*
- * TeleStax, Open Source Cloud Communications
- * Copyright 2011-2016, Telestax Inc and individual contributors
- * by the @authors tag.
- *
- * This program is free software: you can redistribute it and/or modify
- * under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation; either version 3 of
- * the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>
- */
-
-package org.jdiameter.client.impl.router;
-
-import org.jdiameter.api.*;
-import org.jdiameter.api.app.StateChangeListener;
-import org.jdiameter.client.api.IAnswer;
-import org.jdiameter.client.api.IMessage;
-import org.jdiameter.client.api.IRequest;
-import org.jdiameter.client.api.controller.IPeer;
-import org.jdiameter.client.api.controller.IRealmTable;
-import org.jdiameter.client.api.fsm.EventTypes;
-import org.jdiameter.client.api.io.IConnectionListener;
-import org.jdiameter.client.api.io.TransportException;
-import org.jdiameter.client.impl.helpers.XMLConfiguration;
-import org.jdiameter.common.api.statistic.IStatistic;
-import org.jdiameter.common.api.statistic.IStatisticManager;
-import org.jdiameter.common.api.statistic.IStatisticRecord;
-import org.jdiameter.common.impl.controller.AbstractPeer;
-import org.jdiameter.common.impl.statistic.StatisticManagerImpl;
-import org.jdiameter.server.api.agent.IAgentConfiguration;
-import org.testng.annotations.Test;
-
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.URISyntaxException;
-import java.net.UnknownServiceException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import static org.testng.AssertJUnit.assertEquals;
-
-/**
- * Various testcases for Router implementations
- *
- * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
- */
-public class TestRouter {
-
-    @Test
-    public void testWeightedRoundRobin() throws Exception {
-
-        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
-        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
-
-        IStatisticManager manager = new StatisticManagerImpl(config);
-        PeerTest p1 = new PeerTest(1, 1, true, manager);
-        PeerTest p2 = new PeerTest(2, 1, true, manager);
-        PeerTest p3 = new PeerTest(3, 1, true, manager);
-        PeerTest p4 = new PeerTest(4, 1, true, manager);
-
-        List<IPeer> peers = new ArrayList<IPeer>(3);
-        peers.add(p1);
-        peers.add(p2);
-        peers.add(p3);
-
-        // Test simple round robin (all weight = 1)
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-
-        // Test weighted round robin (p1=2, p2=1, p3=1)
-        p1.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-
-        // Test weighted round robin (p1=2, p2=2, p3=1)
-        p2.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-
-        // Test equally weighted round robin (p1=2, p2=2, p3=2)
-        p3.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-
-        // Add Peer-4 with weight 1 to list
-        peers.add(p4);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-
-        // Next cycle would produce Peer-4, but reduce peer list now
-        peers = peers.subList(0,2); // now: Peer-1, Peer-2
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-    }
-
-    @Test
-    public void testWeightedLeastConnections() throws Exception {
-
-        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
-        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
-
-        IStatisticManager manager = new StatisticManagerImpl(config);
-        PeerTest p1 = new PeerTest(1, 1, true, manager);
-        PeerTest p2 = new PeerTest(2, 1, true, manager);
-        PeerTest p3 = new PeerTest(3, 1, true, manager);
-
-        List<IPeer> peers = new ArrayList<IPeer>(2);
-        peers.add(p1);
-        peers.add(p2);
-
-        // Test simple round robin (all weight = 1)
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-        // increase p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-        // decrease p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-        // increase p1 requests/s by 3
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-
-        // increase weight of p1
-        p1.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-        // decrease p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-        // increase p1 requests/s by 2
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-
-        // increase weight and requests/s of p2
-        p2.setRating(2);
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-
-    }
-
-    private static class RealmTableTest implements IRealmTable {
-
-        public Realm matchRealm(IRequest request) {
-            return null;
-        }
-
-        public Realm matchRealm(IAnswer message, String destRealm) {
-            return null;
-        }
-
-        public Realm getRealm(String realmName, ApplicationId applicationId) {
-            return null;
-        }
-
-        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
-            return null;
-        }
-
-        public Collection<Realm> removeRealm(String realmName) {
-            return null;
-        }
-
-        public Collection<Realm> getRealms(String realm) {
-            return null;
-        }
-
-        public Collection<Realm> getRealms() {
-            return null;
-        }
-
-        public String getRealmForPeer(String fqdn) {
-            return null;
-        }
-
-        public void addLocalApplicationId(ApplicationId ap) {
-
-        }
-
-        public void removeLocalApplicationId(ApplicationId a) {
-
-        }
-
-        public void addLocalRealm(String localRealm, String fqdn) {
-
-        }
-
-        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
-            return null;
-        }
-
-        public Statistic getStatistic(String realmName) {
-            return null;
-        }
-
-        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
-            return null;
-        }
-
-        public boolean realmExists(String realmName) {
-            return false;
-        }
-
-        public boolean isWrapperFor(Class<?> iface) throws InternalException {
-            return false;
-        }
-
-        public <T> T unwrap(Class<T> iface) throws InternalException {
-            return null;
-        }
-        
-        public List<String> getAllRealmSet(){
-          return null;
-        }
-    }
-
-    private static class PeerTest extends AbstractPeer implements IPeer {
-
-        private int id;
-        private int rating;
-        private boolean connected;
-
-        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
-            super(new URI("aaa://"+id), manager);
-            this.id = id;
-            this.rating = rating;
-            this.connected = connected;
-            createPeerStatistics();
-        }
-
-        public void setRating(int rating) {
-            this.rating = rating;
-        }
-
-        public int getRating() {
-            return rating;
-        }
-
-        public long getHopByHopIdentifier() {
-            return 0;
-        }
-
-        public void addMessage(IMessage message) {
-
-        }
-
-        public void remMessage(IMessage message) {
-
-        }
-
-        public IMessage[] remAllMessage() {
-            return new IMessage[0];
-        }
-
-        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
-            return false;
-        }
-
-        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
-            return false;
-        }
-
-        public boolean hasValidConnection() {
-            return connected;
-        }
-
-        public void setRealm(String realm) {
-
-        }
-
-        public void addStateChangeListener(StateChangeListener listener) {
-
-        }
-
-        public void remStateChangeListener(StateChangeListener listener) {
-
-        }
-
-        public void addConnectionListener(IConnectionListener listener) {
-
-        }
-
-        public void remConnectionListener(IConnectionListener listener) {
-
-        }
-
-        public IStatistic getStatistic() {
-            return statistic;
-        }
-
-        public boolean isConnected() {
-            return connected;
-        }
-
-        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
-
-        }
-
-        @Override
-        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
-
-        }
-
-        public <E> E getState(Class<E> enumc) {
-            return null;
-        }
-
-        public URI getUri() {
-            return uri;
-        }
-
-        public InetAddress[] getIPAddresses() {
-            return new InetAddress[0];
-        }
-
-        public String getRealmName() {
-            return null;
-        }
-
-        public long getVendorId() {
-            return 0;
-        }
-
-        public String getProductName() {
-            return null;
-        }
-
-        public long getFirmware() {
-            return 0;
-        }
-
-        public Set<ApplicationId> getCommonApplications() {
-            return null;
-        }
-
-        public void addPeerStateListener(PeerStateListener listener) {
-
-        }
-
-        public void removePeerStateListener(PeerStateListener listener) {
-
-        }
-
-        @Override
-        public String toString() {
-            return "Peer-"+id;
-        }
-    }
-
-}
+///*
+// * TeleStax, Open Source Cloud Communications
+// * Copyright 2011-2016, Telestax Inc and individual contributors
+// * by the @authors tag.
+// *
+// * This program is free software: you can redistribute it and/or modify
+// * under the terms of the GNU Affero General Public License as
+// * published by the Free Software Foundation; either version 3 of
+// * the License, or (at your option) any later version.
+// *
+// * This program is distributed in the hope that it will be useful,
+// * but WITHOUT ANY WARRANTY; without even the implied warranty of
+// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// * GNU Affero General Public License for more details.
+// *
+// * You should have received a copy of the GNU Affero General Public License
+// * along with this program.  If not, see <http://www.gnu.org/licenses/>
+// */
+//
+//package org.jdiameter.client.impl.router;
+//
+//import org.jdiameter.api.*;
+//import org.jdiameter.api.app.StateChangeListener;
+//import org.jdiameter.client.api.IAnswer;
+//import org.jdiameter.client.api.IMessage;
+//import org.jdiameter.client.api.IRequest;
+//import org.jdiameter.client.api.controller.IPeer;
+//import org.jdiameter.client.api.controller.IRealmTable;
+//import org.jdiameter.client.api.fsm.EventTypes;
+//import org.jdiameter.client.api.io.IConnectionListener;
+//import org.jdiameter.client.api.io.TransportException;
+//import org.jdiameter.client.impl.helpers.XMLConfiguration;
+//import org.jdiameter.common.api.statistic.IStatistic;
+//import org.jdiameter.common.api.statistic.IStatisticManager;
+//import org.jdiameter.common.api.statistic.IStatisticRecord;
+//import org.jdiameter.common.impl.controller.AbstractPeer;
+//import org.jdiameter.common.impl.statistic.StatisticManagerImpl;
+//import org.jdiameter.server.api.agent.IAgentConfiguration;
+//import org.testng.annotations.Test;
+//
+//import java.io.IOException;
+//import java.net.InetAddress;
+//import java.net.URISyntaxException;
+//import java.net.UnknownServiceException;
+//import java.util.ArrayList;
+//import java.util.Collection;
+//import java.util.List;
+//import java.util.Set;
+//
+//import static org.testng.AssertJUnit.assertEquals;
+//
+///**
+// * Various testcases for Router implementations
+// *
+// * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
+// */
+//public class TestRouter {
+//
+//    @Test
+//    public void testWeightedRoundRobin() throws Exception {
+//
+//        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
+//        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
+//
+//        IStatisticManager manager = new StatisticManagerImpl(config);
+//        PeerTest p1 = new PeerTest(1, 1, true, manager);
+//        PeerTest p2 = new PeerTest(2, 1, true, manager);
+//        PeerTest p3 = new PeerTest(3, 1, true, manager);
+//        PeerTest p4 = new PeerTest(4, 1, true, manager);
+//
+//        List<IPeer> peers = new ArrayList<IPeer>(3);
+//        peers.add(p1);
+//        peers.add(p2);
+//        peers.add(p3);
+//
+//        // Test simple round robin (all weight = 1)
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//
+//        // Test weighted round robin (p1=2, p2=1, p3=1)
+//        p1.setRating(2);
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//
+//        // Test weighted round robin (p1=2, p2=2, p3=1)
+//        p2.setRating(2);
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//
+//        // Test equally weighted round robin (p1=2, p2=2, p3=2)
+//        p3.setRating(2);
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//
+//        // Add Peer-4 with weight 1 to list
+//        peers.add(p4);
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
+//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+//
+//        // Next cycle would produce Peer-4, but reduce peer list now
+//        peers = peers.subList(0,2); // now: Peer-1, Peer-2
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//    }
+//
+//    @Test
+//    public void testWeightedLeastConnections() throws Exception {
+//
+//        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
+//        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
+//
+//        IStatisticManager manager = new StatisticManagerImpl(config);
+//        PeerTest p1 = new PeerTest(1, 1, true, manager);
+//        PeerTest p2 = new PeerTest(2, 1, true, manager);
+//        PeerTest p3 = new PeerTest(3, 1, true, manager);
+//
+//        List<IPeer> peers = new ArrayList<IPeer>(2);
+//        peers.add(p1);
+//        peers.add(p2);
+//
+//        // Test simple round robin (all weight = 1)
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p1 requests/s by 1
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p2 requests/s by 1
+//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//        // decrease p1 requests/s by 1
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p1 requests/s by 3
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p2 requests/s by 1
+//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//
+//        // increase weight of p1
+//        p1.setRating(2);
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//        // decrease p1 requests/s by 1
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p1 requests/s by 2
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//
+//        // increase weight and requests/s of p2
+//        p2.setRating(2);
+//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+//
+//        // increase p2 requests/s by 1
+//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+//
+//    }
+//
+//    private static class RealmTableTest implements IRealmTable {
+//
+//        public Realm matchRealm(IRequest request) {
+//            return null;
+//        }
+//
+//        public Realm matchRealm(IAnswer message, String destRealm) {
+//            return null;
+//        }
+//
+//        public Realm getRealm(String realmName, ApplicationId applicationId) {
+//            return null;
+//        }
+//
+//        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
+//            return null;
+//        }
+//
+//        public Collection<Realm> removeRealm(String realmName) {
+//            return null;
+//        }
+//
+//        public Collection<Realm> getRealms(String realm) {
+//            return null;
+//        }
+//
+//        public Collection<Realm> getRealms() {
+//            return null;
+//        }
+//
+//        public String getRealmForPeer(String fqdn) {
+//            return null;
+//        }
+//
+//        public void addLocalApplicationId(ApplicationId ap) {
+//
+//        }
+//
+//        public void removeLocalApplicationId(ApplicationId a) {
+//
+//        }
+//
+//        public void addLocalRealm(String localRealm, String fqdn) {
+//
+//        }
+//
+//        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
+//            return null;
+//        }
+//
+//        public Statistic getStatistic(String realmName) {
+//            return null;
+//        }
+//
+//        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
+//            return null;
+//        }
+//
+//        public boolean realmExists(String realmName) {
+//            return false;
+//        }
+//
+//        public boolean isWrapperFor(Class<?> iface) throws InternalException {
+//            return false;
+//        }
+//
+//        public <T> T unwrap(Class<T> iface) throws InternalException {
+//            return null;
+//        }
+//
+//        public List<String> getAllRealmSet(){
+//          return null;
+//        }
+//    }
+//
+//    private static class PeerTest extends AbstractPeer implements IPeer {
+//
+//        private int id;
+//        private int rating;
+//        private boolean connected;
+//
+//        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
+//            super(new URI("aaa://"+id), manager);
+//            this.id = id;
+//            this.rating = rating;
+//            this.connected = connected;
+//            createPeerStatistics();
+//        }
+//
+//        public void setRating(int rating) {
+//            this.rating = rating;
+//        }
+//
+//        public int getRating() {
+//            return rating;
+//        }
+//
+//        public long getHopByHopIdentifier() {
+//            return 0;
+//        }
+//
+//        public void addMessage(IMessage message) {
+//
+//        }
+//
+//        public void remMessage(IMessage message) {
+//
+//        }
+//
+//        public IMessage[] remAllMessage() {
+//            return new IMessage[0];
+//        }
+//
+//        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
+//            return false;
+//        }
+//
+//        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
+//            return false;
+//        }
+//
+//        public boolean hasValidConnection() {
+//            return connected;
+//        }
+//
+//        public void setRealm(String realm) {
+//
+//        }
+//
+//        public void addStateChangeListener(StateChangeListener listener) {
+//
+//        }
+//
+//        public void remStateChangeListener(StateChangeListener listener) {
+//
+//        }
+//
+//        public void addConnectionListener(IConnectionListener listener) {
+//
+//        }
+//
+//        public void remConnectionListener(IConnectionListener listener) {
+//
+//        }
+//
+//        public IStatistic getStatistic() {
+//            return statistic;
+//        }
+//
+//        public boolean isConnected() {
+//            return connected;
+//        }
+//
+//        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
+//
+//        }
+//
+//        @Override
+//        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
+//
+//        }
+//
+//        public <E> E getState(Class<E> enumc) {
+//            return null;
+//        }
+//
+//        public URI getUri() {
+//            return uri;
+//        }
+//
+//        public InetAddress[] getIPAddresses() {
+//            return new InetAddress[0];
+//        }
+//
+//        public String getRealmName() {
+//            return null;
+//        }
+//
+//        public long getVendorId() {
+//            return 0;
+//        }
+//
+//        public String getProductName() {
+//            return null;
+//        }
+//
+//        public long getFirmware() {
+//            return 0;
+//        }
+//
+//        public Set<ApplicationId> getCommonApplications() {
+//            return null;
+//        }
+//
+//        public void addPeerStateListener(PeerStateListener listener) {
+//
+//        }
+//
+//        public void removePeerStateListener(PeerStateListener listener) {
+//
+//        }
+//
+//        @Override
+//        public String toString() {
+//            return "Peer-"+id;
+//        }
+//    }
+//
+//}

--- a/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
+++ b/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
@@ -72,105 +72,105 @@ public class TestRouter extends TestCase {
   private static final Logger logger = LoggerFactory.getLogger(TestRouter.class);
   private static UIDGenerator uid = new UIDGenerator();
 
-    @Test
-    public void testWeightedRoundRobin() throws Exception {
+  @Test
+  public void testWeightedRoundRobin() throws Exception {
 
-        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
-        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
+    Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
+    WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
 
-        IStatisticManager manager = new StatisticManagerImpl(config);
-        PeerTest p1 = new PeerTest(1, 1, true, manager);
-        PeerTest p2 = new PeerTest(2, 1, true, manager);
-        PeerTest p3 = new PeerTest(3, 1, true, manager);
-        PeerTest p4 = new PeerTest(4, 1, true, manager);
+    IStatisticManager manager = new StatisticManagerImpl(config);
+    PeerTest p1 = new PeerTest(1, 1, true, manager);
+    PeerTest p2 = new PeerTest(2, 1, true, manager);
+    PeerTest p3 = new PeerTest(3, 1, true, manager);
+    PeerTest p4 = new PeerTest(4, 1, true, manager);
 
-        List<IPeer> peers = new ArrayList<IPeer>(3);
-        peers.add(p1);
-        peers.add(p2);
-        peers.add(p3);
+    List<IPeer> peers = new ArrayList<IPeer>(3);
+    peers.add(p1);
+    peers.add(p2);
+    peers.add(p3);
 
-        // Test simple round robin (all weight = 1)
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // Test simple round robin (all weight = 1)
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
 
-        // Test weighted round robin (p1=2, p2=1, p3=1)
-        p1.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // Test weighted round robin (p1=2, p2=1, p3=1)
+    p1.setRating(2);
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
 
-        // Test weighted round robin (p1=2, p2=2, p3=1)
-        p2.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // Test weighted round robin (p1=2, p2=2, p3=1)
+    p2.setRating(2);
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
 
-        // Test equally weighted round robin (p1=2, p2=2, p3=2)
-        p3.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // Test equally weighted round robin (p1=2, p2=2, p3=2)
+    p3.setRating(2);
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
 
-        // Add Peer-4 with weight 1 to list
-        peers.add(p4);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // Add Peer-4 with weight 1 to list
+    peers.add(p4);
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
+    assertEquals(p4.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p4.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
+    assertEquals(p4.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p3.toString(), router.selectPeer(peers).toString());
 
-        // Next cycle would produce Peer-4, but reduce peer list now
-        peers = peers.subList(0,2); // now: Peer-1, Peer-2
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // Next cycle would produce Peer-4, but reduce peer list now
+    peers = peers.subList(0, 2); // now: Peer-1, Peer-2
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-    }
+  }
 
   /*
    * WeightedRoundRobinResubmittingRouter should behave exactly as the WeightedRoundRobinRouter
@@ -363,7 +363,6 @@ public class TestRouter extends TestCase {
     logger.debug("*** Execution of testWeightedRoundRobinResubmittingPeersExhaused completed ***");
   }
 
-
   /*
    * Validates that, when a peer responds with a Busy or Unable to Deliver Answer, an alternative peer is
    * selected to resubmit the Request to, based on the existing Round Robin weighting algorithm, also after
@@ -424,299 +423,301 @@ public class TestRouter extends TestCase {
     return sb.toString();
   }
 
-    @Test
-    public void testWeightedLeastConnections() throws Exception {
+  @Test
+  public void testWeightedLeastConnections() throws Exception {
 
-        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
-        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
+    Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
+    WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
 
-        IStatisticManager manager = new StatisticManagerImpl(config);
-        PeerTest p1 = new PeerTest(1, 1, true, manager);
-        PeerTest p2 = new PeerTest(2, 1, true, manager);
-        PeerTest p3 = new PeerTest(3, 1, true, manager);
+    IStatisticManager manager = new StatisticManagerImpl(config);
+    PeerTest p1 = new PeerTest(1, 1, true, manager);
+    PeerTest p2 = new PeerTest(2, 1, true, manager);
+    PeerTest p3 = new PeerTest(3, 1, true, manager);
 
-        List<IPeer> peers = new ArrayList<IPeer>(2);
-        peers.add(p1);
-        peers.add(p2);
+    List<IPeer> peers = new ArrayList<IPeer>(2);
+    peers.add(p1);
+    peers.add(p2);
 
-        // Test simple round robin (all weight = 1)
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // Test simple round robin (all weight = 1)
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-        // increase p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    // increase p1 requests/s by 1
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
 
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // increase p2 requests/s by 1
+    p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name() + '.' + p2.getUri()).inc();
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-        // decrease p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // decrease p1 requests/s by 1
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name() + '.' + p1.getUri()).dec();
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-        // increase p1 requests/s by 3
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    // increase p1 requests/s by 3
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
 
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    // increase p2 requests/s by 1
+    p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name() + '.' + p2.getUri()).inc();
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
 
-        // increase weight of p1
-        p1.setRating(2);
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // increase weight of p1
+    p1.setRating(2);
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-        // decrease p1 requests/s by 1
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // decrease p1 requests/s by 1
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).dec();
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
 
-        // increase p1 requests/s by 2
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    // increase p1 requests/s by 2
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name() + '.' + p1.getUri()).inc();
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
 
-        // increase weight and requests/s of p2
-        p2.setRating(2);
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    // increase weight and requests/s of p2
+    p2.setRating(2);
+    p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name() + '.' + p2.getUri()).inc();
+    p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name() + '.' + p2.getUri()).inc();
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
+    assertEquals(p2.toString(), router.selectPeer(peers).toString());
 
-        // increase p2 requests/s by 1
-        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    // increase p2 requests/s by 1
+    p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name() + '.' + p2.getUri()).inc();
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+    assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+  }
+
+  private static class RealmTableTest implements IRealmTable {
+
+    public Realm matchRealm(IRequest request) {
+      return null;
+    }
+
+    public Realm matchRealm(IAnswer message, String destRealm) {
+      return null;
+    }
+
+    public Realm getRealm(String realmName, ApplicationId applicationId) {
+      return null;
+    }
+
+    public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
+      return null;
+    }
+
+    public Collection<Realm> removeRealm(String realmName) {
+      return null;
+    }
+
+    public Collection<Realm> getRealms(String realm) {
+      return null;
+    }
+
+    public Collection<Realm> getRealms() {
+      return null;
+    }
+
+    public String getRealmForPeer(String fqdn) {
+      return null;
+    }
+
+    public void addLocalApplicationId(ApplicationId ap) {
 
     }
 
-    private static class RealmTableTest implements IRealmTable {
+    public void removeLocalApplicationId(ApplicationId a) {
 
-        public Realm matchRealm(IRequest request) {
-            return null;
-        }
-
-        public Realm matchRealm(IAnswer message, String destRealm) {
-            return null;
-        }
-
-        public Realm getRealm(String realmName, ApplicationId applicationId) {
-            return null;
-        }
-
-        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
-            return null;
-        }
-
-        public Collection<Realm> removeRealm(String realmName) {
-            return null;
-        }
-
-        public Collection<Realm> getRealms(String realm) {
-            return null;
-        }
-
-        public Collection<Realm> getRealms() {
-            return null;
-        }
-
-        public String getRealmForPeer(String fqdn) {
-            return null;
-        }
-
-        public void addLocalApplicationId(ApplicationId ap) {
-
-        }
-
-        public void removeLocalApplicationId(ApplicationId a) {
-
-        }
-
-        public void addLocalRealm(String localRealm, String fqdn) {
-
-        }
-
-        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
-            return null;
-        }
-
-        public Statistic getStatistic(String realmName) {
-            return null;
-        }
-
-        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
-            return null;
-        }
-
-        public boolean realmExists(String realmName) {
-            return false;
-        }
-
-        public boolean isWrapperFor(Class<?> iface) throws InternalException {
-            return false;
-        }
-
-        public <T> T unwrap(Class<T> iface) throws InternalException {
-            return null;
-        }
-
-        public List<String> getAllRealmSet(){
-          return null;
-        }
     }
 
-    private static class PeerTest extends AbstractPeer implements IPeer {
+    public void addLocalRealm(String localRealm, String fqdn) {
 
-        private int id;
-        private int rating;
-        private boolean connected;
-
-        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
-            super(new URI("aaa://"+id), manager);
-            this.id = id;
-            this.rating = rating;
-            this.connected = connected;
-            createPeerStatistics();
-        }
-
-        public void setRating(int rating) {
-            this.rating = rating;
-        }
-
-        public int getRating() {
-            return rating;
-        }
-
-        public long getHopByHopIdentifier() {
-            return 0;
-        }
-
-        public void addMessage(IMessage message) {
-
-        }
-
-        public void remMessage(IMessage message) {
-
-        }
-
-        public IMessage[] remAllMessage() {
-            return new IMessage[0];
-        }
-
-        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
-            return false;
-        }
-
-        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
-            return false;
-        }
-
-        public boolean hasValidConnection() {
-            return connected;
-        }
-
-        public void setRealm(String realm) {
-
-        }
-
-        public void addStateChangeListener(StateChangeListener listener) {
-
-        }
-
-        public void remStateChangeListener(StateChangeListener listener) {
-
-        }
-
-        public void addConnectionListener(IConnectionListener listener) {
-
-        }
-
-        public void remConnectionListener(IConnectionListener listener) {
-
-        }
-
-        public IStatistic getStatistic() {
-            return statistic;
-        }
-
-        public boolean isConnected() {
-            return connected;
-        }
-
-        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
-
-        }
-
-        @Override
-        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
-
-        }
-
-        public <E> E getState(Class<E> enumc) {
-            return null;
-        }
-
-        public URI getUri() {
-            return uri;
-        }
-
-        public InetAddress[] getIPAddresses() {
-            return new InetAddress[0];
-        }
-
-        public String getRealmName() {
-            return null;
-        }
-
-        public long getVendorId() {
-            return 0;
-        }
-
-        public String getProductName() {
-            return null;
-        }
-
-        public long getFirmware() {
-            return 0;
-        }
-
-        public Set<ApplicationId> getCommonApplications() {
-            return null;
-        }
-
-        public void addPeerStateListener(PeerStateListener listener) {
-
-        }
-
-        public void removePeerStateListener(PeerStateListener listener) {
-
-        }
-
-        @Override
-        public String toString() {
-            return "Peer-"+id;
-        }
     }
+
+    public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime,
+        String[] hosts) throws InternalException {
+      return null;
+    }
+
+    public Statistic getStatistic(String realmName) {
+      return null;
+    }
+
+    public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime,
+        String[] hosts) throws InternalException {
+      return null;
+    }
+
+    public boolean realmExists(String realmName) {
+      return false;
+    }
+
+    public boolean isWrapperFor(Class<?> iface) throws InternalException {
+      return false;
+    }
+
+    public <T> T unwrap(Class<T> iface) throws InternalException {
+      return null;
+    }
+
+    public List<String> getAllRealmSet() {
+      return null;
+    }
+  }
+
+  private static class PeerTest extends AbstractPeer implements IPeer {
+
+    private int id;
+    private int rating;
+    private boolean connected;
+
+    public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
+      super(new URI("aaa://" + id), manager);
+      this.id = id;
+      this.rating = rating;
+      this.connected = connected;
+      createPeerStatistics();
+    }
+
+    public void setRating(int rating) {
+      this.rating = rating;
+    }
+
+    public int getRating() {
+      return rating;
+    }
+
+    public long getHopByHopIdentifier() {
+      return 0;
+    }
+
+    public void addMessage(IMessage message) {
+
+    }
+
+    public void remMessage(IMessage message) {
+
+    }
+
+    public IMessage[] remAllMessage() {
+      return new IMessage[0];
+    }
+
+    public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
+      return false;
+    }
+
+    public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
+      return false;
+    }
+
+    public boolean hasValidConnection() {
+      return connected;
+    }
+
+    public void setRealm(String realm) {
+
+    }
+
+    public void addStateChangeListener(StateChangeListener listener) {
+
+    }
+
+    public void remStateChangeListener(StateChangeListener listener) {
+
+    }
+
+    public void addConnectionListener(IConnectionListener listener) {
+
+    }
+
+    public void remConnectionListener(IConnectionListener listener) {
+
+    }
+
+    public IStatistic getStatistic() {
+      return statistic;
+    }
+
+    public boolean isConnected() {
+      return connected;
+    }
+
+    public void connect() throws InternalException, IOException, IllegalDiameterStateException {
+
+    }
+
+    @Override
+    public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
+
+    }
+
+    public <E> E getState(Class<E> enumc) {
+      return null;
+    }
+
+    public URI getUri() {
+      return uri;
+    }
+
+    public InetAddress[] getIPAddresses() {
+      return new InetAddress[0];
+    }
+
+    public String getRealmName() {
+      return null;
+    }
+
+    public long getVendorId() {
+      return 0;
+    }
+
+    public String getProductName() {
+      return null;
+    }
+
+    public long getFirmware() {
+      return 0;
+    }
+
+    public Set<ApplicationId> getCommonApplications() {
+      return null;
+    }
+
+    public void addPeerStateListener(PeerStateListener listener) {
+
+    }
+
+    public void removePeerStateListener(PeerStateListener listener) {
+
+    }
+
+    @Override
+    public String toString() {
+      return "Peer-" + id;
+    }
+  }
 
 }

--- a/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
+++ b/core/jdiameter/impl/src/test/java/org/jdiameter/client/impl/router/TestRouter.java
@@ -1,454 +1,529 @@
-///*
-// * TeleStax, Open Source Cloud Communications
-// * Copyright 2011-2016, Telestax Inc and individual contributors
-// * by the @authors tag.
-// *
-// * This program is free software: you can redistribute it and/or modify
-// * under the terms of the GNU Affero General Public License as
-// * published by the Free Software Foundation; either version 3 of
-// * the License, or (at your option) any later version.
-// *
-// * This program is distributed in the hope that it will be useful,
-// * but WITHOUT ANY WARRANTY; without even the implied warranty of
-// * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// * GNU Affero General Public License for more details.
-// *
-// * You should have received a copy of the GNU Affero General Public License
-// * along with this program.  If not, see <http://www.gnu.org/licenses/>
-// */
-//
-//package org.jdiameter.client.impl.router;
-//
-//import org.jdiameter.api.*;
-//import org.jdiameter.api.app.StateChangeListener;
-//import org.jdiameter.client.api.IAnswer;
-//import org.jdiameter.client.api.IMessage;
-//import org.jdiameter.client.api.IRequest;
-//import org.jdiameter.client.api.controller.IPeer;
-//import org.jdiameter.client.api.controller.IRealmTable;
-//import org.jdiameter.client.api.fsm.EventTypes;
-//import org.jdiameter.client.api.io.IConnectionListener;
-//import org.jdiameter.client.api.io.TransportException;
-//import org.jdiameter.client.impl.helpers.XMLConfiguration;
-//import org.jdiameter.common.api.statistic.IStatistic;
-//import org.jdiameter.common.api.statistic.IStatisticManager;
-//import org.jdiameter.common.api.statistic.IStatisticRecord;
-//import org.jdiameter.common.impl.controller.AbstractPeer;
-//import org.jdiameter.common.impl.statistic.StatisticManagerImpl;
-//import org.jdiameter.server.api.agent.IAgentConfiguration;
-//import org.testng.annotations.Test;
-//
-//import java.io.IOException;
-//import java.net.InetAddress;
-//import java.net.URISyntaxException;
-//import java.net.UnknownServiceException;
-//import java.util.ArrayList;
-//import java.util.Collection;
-//import java.util.List;
-//import java.util.Set;
-//
-//import static org.testng.AssertJUnit.assertEquals;
-//
-///**
-// * Various testcases for Router implementations
-// *
-// * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
-// */
-//public class TestRouter {
-//
-//    @Test
-//    public void testWeightedRoundRobin() throws Exception {
-//
-//        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
-//        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
-//
-//        IStatisticManager manager = new StatisticManagerImpl(config);
-//        PeerTest p1 = new PeerTest(1, 1, true, manager);
-//        PeerTest p2 = new PeerTest(2, 1, true, manager);
-//        PeerTest p3 = new PeerTest(3, 1, true, manager);
-//        PeerTest p4 = new PeerTest(4, 1, true, manager);
-//
-//        List<IPeer> peers = new ArrayList<IPeer>(3);
-//        peers.add(p1);
-//        peers.add(p2);
-//        peers.add(p3);
-//
-//        // Test simple round robin (all weight = 1)
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//
-//        // Test weighted round robin (p1=2, p2=1, p3=1)
-//        p1.setRating(2);
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//
-//        // Test weighted round robin (p1=2, p2=2, p3=1)
-//        p2.setRating(2);
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//
-//        // Test equally weighted round robin (p1=2, p2=2, p3=2)
-//        p3.setRating(2);
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//
-//        // Add Peer-4 with weight 1 to list
-//        peers.add(p4);
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
-//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p4.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p3.toString(), router.selectPeer(peers).toString());
-//
-//        // Next cycle would produce Peer-4, but reduce peer list now
-//        peers = peers.subList(0,2); // now: Peer-1, Peer-2
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//    }
-//
-//    @Test
-//    public void testWeightedLeastConnections() throws Exception {
-//
-//        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
-//        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
-//
-//        IStatisticManager manager = new StatisticManagerImpl(config);
-//        PeerTest p1 = new PeerTest(1, 1, true, manager);
-//        PeerTest p2 = new PeerTest(2, 1, true, manager);
-//        PeerTest p3 = new PeerTest(3, 1, true, manager);
-//
-//        List<IPeer> peers = new ArrayList<IPeer>(2);
-//        peers.add(p1);
-//        peers.add(p2);
-//
-//        // Test simple round robin (all weight = 1)
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p1 requests/s by 1
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p2 requests/s by 1
-//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//        // decrease p1 requests/s by 1
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p1 requests/s by 3
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p2 requests/s by 1
-//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//
-//        // increase weight of p1
-//        p1.setRating(2);
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//        // decrease p1 requests/s by 1
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p1 requests/s by 2
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//
-//        // increase weight and requests/s of p2
-//        p2.setRating(2);
-//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p2.toString(), router.selectPeer(peers).toString());
-//
-//        // increase p2 requests/s by 1
-//        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//        assertEquals(p1.toString(), router.selectPeer(peers).toString());
-//
-//    }
-//
-//    private static class RealmTableTest implements IRealmTable {
-//
-//        public Realm matchRealm(IRequest request) {
-//            return null;
-//        }
-//
-//        public Realm matchRealm(IAnswer message, String destRealm) {
-//            return null;
-//        }
-//
-//        public Realm getRealm(String realmName, ApplicationId applicationId) {
-//            return null;
-//        }
-//
-//        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
-//            return null;
-//        }
-//
-//        public Collection<Realm> removeRealm(String realmName) {
-//            return null;
-//        }
-//
-//        public Collection<Realm> getRealms(String realm) {
-//            return null;
-//        }
-//
-//        public Collection<Realm> getRealms() {
-//            return null;
-//        }
-//
-//        public String getRealmForPeer(String fqdn) {
-//            return null;
-//        }
-//
-//        public void addLocalApplicationId(ApplicationId ap) {
-//
-//        }
-//
-//        public void removeLocalApplicationId(ApplicationId a) {
-//
-//        }
-//
-//        public void addLocalRealm(String localRealm, String fqdn) {
-//
-//        }
-//
-//        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
-//            return null;
-//        }
-//
-//        public Statistic getStatistic(String realmName) {
-//            return null;
-//        }
-//
-//        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
-//            return null;
-//        }
-//
-//        public boolean realmExists(String realmName) {
-//            return false;
-//        }
-//
-//        public boolean isWrapperFor(Class<?> iface) throws InternalException {
-//            return false;
-//        }
-//
-//        public <T> T unwrap(Class<T> iface) throws InternalException {
-//            return null;
-//        }
-//
-//        public List<String> getAllRealmSet(){
-//          return null;
-//        }
-//    }
-//
-//    private static class PeerTest extends AbstractPeer implements IPeer {
-//
-//        private int id;
-//        private int rating;
-//        private boolean connected;
-//
-//        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
-//            super(new URI("aaa://"+id), manager);
-//            this.id = id;
-//            this.rating = rating;
-//            this.connected = connected;
-//            createPeerStatistics();
-//        }
-//
-//        public void setRating(int rating) {
-//            this.rating = rating;
-//        }
-//
-//        public int getRating() {
-//            return rating;
-//        }
-//
-//        public long getHopByHopIdentifier() {
-//            return 0;
-//        }
-//
-//        public void addMessage(IMessage message) {
-//
-//        }
-//
-//        public void remMessage(IMessage message) {
-//
-//        }
-//
-//        public IMessage[] remAllMessage() {
-//            return new IMessage[0];
-//        }
-//
-//        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
-//            return false;
-//        }
-//
-//        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
-//            return false;
-//        }
-//
-//        public boolean hasValidConnection() {
-//            return connected;
-//        }
-//
-//        public void setRealm(String realm) {
-//
-//        }
-//
-//        public void addStateChangeListener(StateChangeListener listener) {
-//
-//        }
-//
-//        public void remStateChangeListener(StateChangeListener listener) {
-//
-//        }
-//
-//        public void addConnectionListener(IConnectionListener listener) {
-//
-//        }
-//
-//        public void remConnectionListener(IConnectionListener listener) {
-//
-//        }
-//
-//        public IStatistic getStatistic() {
-//            return statistic;
-//        }
-//
-//        public boolean isConnected() {
-//            return connected;
-//        }
-//
-//        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
-//
-//        }
-//
-//        @Override
-//        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
-//
-//        }
-//
-//        public <E> E getState(Class<E> enumc) {
-//            return null;
-//        }
-//
-//        public URI getUri() {
-//            return uri;
-//        }
-//
-//        public InetAddress[] getIPAddresses() {
-//            return new InetAddress[0];
-//        }
-//
-//        public String getRealmName() {
-//            return null;
-//        }
-//
-//        public long getVendorId() {
-//            return 0;
-//        }
-//
-//        public String getProductName() {
-//            return null;
-//        }
-//
-//        public long getFirmware() {
-//            return 0;
-//        }
-//
-//        public Set<ApplicationId> getCommonApplications() {
-//            return null;
-//        }
-//
-//        public void addPeerStateListener(PeerStateListener listener) {
-//
-//        }
-//
-//        public void removePeerStateListener(PeerStateListener listener) {
-//
-//        }
-//
-//        @Override
-//        public String toString() {
-//            return "Peer-"+id;
-//        }
-//    }
-//
-//}
+/*
+ * TeleStax, Open Source Cloud Communications
+ * Copyright 2011-2016, Telestax Inc and individual contributors
+ * by the @authors tag.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation; either version 3 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+package org.jdiameter.client.impl.router;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.URISyntaxException;
+import java.net.UnknownServiceException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import org.jdiameter.api.ApplicationId;
+import org.jdiameter.api.Avp;
+import org.jdiameter.api.AvpDataException;
+import org.jdiameter.api.Configuration;
+import org.jdiameter.api.IllegalDiameterStateException;
+import org.jdiameter.api.InternalException;
+import org.jdiameter.api.LocalAction;
+import org.jdiameter.api.OverloadException;
+import org.jdiameter.api.PeerStateListener;
+import org.jdiameter.api.Realm;
+import org.jdiameter.api.Statistic;
+import org.jdiameter.api.URI;
+import org.jdiameter.api.app.StateChangeListener;
+import org.jdiameter.client.api.IAnswer;
+import org.jdiameter.client.api.IMessage;
+import org.jdiameter.client.api.IRequest;
+import org.jdiameter.client.api.controller.IPeer;
+import org.jdiameter.client.api.controller.IRealmTable;
+import org.jdiameter.client.api.fsm.EventTypes;
+import org.jdiameter.client.api.io.IConnectionListener;
+import org.jdiameter.client.api.io.TransportException;
+import org.jdiameter.client.impl.helpers.UIDGenerator;
+import org.jdiameter.client.impl.helpers.XMLConfiguration;
+import org.jdiameter.client.impl.parser.MessageParser;
+import org.jdiameter.common.api.statistic.IStatistic;
+import org.jdiameter.common.api.statistic.IStatisticManager;
+import org.jdiameter.common.api.statistic.IStatisticRecord;
+import org.jdiameter.common.impl.controller.AbstractPeer;
+import org.jdiameter.common.impl.statistic.StatisticManagerImpl;
+import org.jdiameter.server.api.agent.IAgentConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import junit.framework.TestCase;
+
+/**
+ * Various testcases for Router implementations
+ *
+ * @author <a href="mailto:n.sowen@2scale.net">Nils Sowen</a>
+ */
+public class TestRouter extends TestCase {
+  private static final Logger logger = LoggerFactory.getLogger(TestRouter.class);
+  private static UIDGenerator uid = new UIDGenerator();
+
+    @Test
+    public void testWeightedRoundRobin() throws Exception {
+
+        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobin-config.xml");
+        WeightedRoundRobinRouter router = new WeightedRoundRobinRouter(new RealmTableTest(), config);
+
+        IStatisticManager manager = new StatisticManagerImpl(config);
+        PeerTest p1 = new PeerTest(1, 1, true, manager);
+        PeerTest p2 = new PeerTest(2, 1, true, manager);
+        PeerTest p3 = new PeerTest(3, 1, true, manager);
+        PeerTest p4 = new PeerTest(4, 1, true, manager);
+
+        List<IPeer> peers = new ArrayList<IPeer>(3);
+        peers.add(p1);
+        peers.add(p2);
+        peers.add(p3);
+
+        // Test simple round robin (all weight = 1)
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test weighted round robin (p1=2, p2=1, p3=1)
+        p1.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test weighted round robin (p1=2, p2=2, p3=1)
+        p2.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Test equally weighted round robin (p1=2, p2=2, p3=2)
+        p3.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Add Peer-4 with weight 1 to list
+        peers.add(p4);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        // expected glitch here: due to the sudden availibity of Peer-4, the algorithm is disturbed
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+        assertEquals(p4.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p3.toString(), router.selectPeer(peers).toString());
+
+        // Next cycle would produce Peer-4, but reduce peer list now
+        peers = peers.subList(0,2); // now: Peer-1, Peer-2
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+    }
+
+    @Test
+    public void testWeightedRoundRobinResubmittingOnBusyOrUnableToDeliverAnswer() throws Exception {
+
+      Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml");
+      WeightedRoundRobinResubmittingRouter router = new WeightedRoundRobinResubmittingRouter(new RealmTableTest(), config);
+
+      IStatisticManager manager = new StatisticManagerImpl(config);
+      PeerTest p1 = new PeerTest(1, 1, true, manager);
+      PeerTest p2 = new PeerTest(2, 2, true, manager);
+      PeerTest p3 = new PeerTest(3, 3, true, manager);
+      PeerTest p4 = new PeerTest(4, 4, true, manager);
+
+      List<IPeer> peers = new ArrayList<IPeer>(3);
+      peers.add(p1);
+      peers.add(p2);
+      peers.add(p3);
+      peers.add(p4);
+
+      // Create any message
+      MessageParser messageParser = new MessageParser();
+      IMessage request = messageParser.createEmptyMessage(123, 3l);
+      request.getAvps().addAvp(Avp.CC_REQUEST_NUMBER, 0);
+      request.setRequest(true);
+      request.getAvps().addAvp(Avp.SESSION_ID, getSessionId(), true, false, false);
+
+      // Test weighted round robin on a single, resubmitted request
+      assertEquals(p4.toString(), router.selectPeer(request, peers).toString());
+      emulateResubmission(p4, request);
+      assertEquals(p3.toString(), router.selectPeer(request, peers).toString());
+      emulateResubmission(p3, request);
+      assertEquals(p2.toString(), router.selectPeer(request, peers).toString());
+      emulateResubmission(p2, request);
+      assertEquals(p1.toString(), router.selectPeer(request, peers).toString());
+    }
+
+    private void emulateResubmission(PeerTest peer, IMessage request) throws AvpDataException {
+      request.setPeer(peer);
+      incrementRequestNumber(request);
+    }
+
+    private void incrementRequestNumber(IMessage request) throws AvpDataException {
+      int requestNumber = request.getAvps().getAvp(Avp.CC_REQUEST_NUMBER).getInteger32();
+      requestNumber++;
+      logger.trace("Incremented requestNumber to [{}] ", requestNumber);
+      request.getAvps().removeAvp(Avp.CC_REQUEST_NUMBER);
+      request.getAvps().addAvp(Avp.CC_REQUEST_NUMBER, requestNumber); 
+    }
+
+    private String getSessionId() {
+      long id = uid.nextLong();
+      long high32 = (id & 0xffffffff00000000L) >> 32;
+      long low32 = (id & 0xffffffffL);
+      StringBuilder sb = new StringBuilder();
+      sb.append("localhost").
+      append(";").append(high32).append(";").append(low32);
+      return sb.toString();  
+    }
+
+    @Test
+    public void testWeightedLeastConnections() throws Exception {
+
+        Configuration config = new XMLConfiguration("src/test/resources/jdiameter-weightedleastconnections-config.xml");
+        WeightedLeastConnectionsRouter router = new WeightedLeastConnectionsRouter(new RealmTableTest(), config);
+
+        IStatisticManager manager = new StatisticManagerImpl(config);
+        PeerTest p1 = new PeerTest(1, 1, true, manager);
+        PeerTest p2 = new PeerTest(2, 1, true, manager);
+        PeerTest p3 = new PeerTest(3, 1, true, manager);
+
+        List<IPeer> peers = new ArrayList<IPeer>(2);
+        peers.add(p1);
+        peers.add(p2);
+
+        // Test simple round robin (all weight = 1)
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // decrease p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenResponsePerSecond.name()+'.'+p1.getUri()).dec();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 3
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase weight of p1
+        p1.setRating(2);
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // decrease p1 requests/s by 1
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).dec();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+        // increase p1 requests/s by 2
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        p1.getStatistic().getRecordByName(IStatisticRecord.Counters.AppGenRequestPerSecond.name()+'.'+p1.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase weight and requests/s of p2
+        p2.setRating(2);
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+        assertEquals(p2.toString(), router.selectPeer(peers).toString());
+
+        // increase p2 requests/s by 1
+        p2.getStatistic().getRecordByName(IStatisticRecord.Counters.NetGenRequestPerSecond.name()+'.'+p2.getUri()).inc();
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+        assertEquals(p1.toString(), router.selectPeer(peers).toString());
+
+    }
+
+    private static class RealmTableTest implements IRealmTable {
+
+        public Realm matchRealm(IRequest request) {
+            return null;
+        }
+
+        public Realm matchRealm(IAnswer message, String destRealm) {
+            return null;
+        }
+
+        public Realm getRealm(String realmName, ApplicationId applicationId) {
+            return null;
+        }
+
+        public Realm removeRealmApplicationId(String realmName, ApplicationId appId) {
+            return null;
+        }
+
+        public Collection<Realm> removeRealm(String realmName) {
+            return null;
+        }
+
+        public Collection<Realm> getRealms(String realm) {
+            return null;
+        }
+
+        public Collection<Realm> getRealms() {
+            return null;
+        }
+
+        public String getRealmForPeer(String fqdn) {
+            return null;
+        }
+
+        public void addLocalApplicationId(ApplicationId ap) {
+
+        }
+
+        public void removeLocalApplicationId(ApplicationId a) {
+
+        }
+
+        public void addLocalRealm(String localRealm, String fqdn) {
+
+        }
+
+        public Realm addRealm(String name, ApplicationId appId, LocalAction locAction, IAgentConfiguration agentConfImpl, boolean isDynamic, long expirationTime, String[] hosts) throws InternalException {
+            return null;
+        }
+
+        public Statistic getStatistic(String realmName) {
+            return null;
+        }
+
+        public Realm addRealm(String realmName, ApplicationId applicationId, LocalAction action, String agentConfiguration, boolean dynamic, long expirationTime, String[] hosts) throws InternalException {
+            return null;
+        }
+
+        public boolean realmExists(String realmName) {
+            return false;
+        }
+
+        public boolean isWrapperFor(Class<?> iface) throws InternalException {
+            return false;
+        }
+
+        public <T> T unwrap(Class<T> iface) throws InternalException {
+            return null;
+        }
+
+        public List<String> getAllRealmSet(){
+          return null;
+        }
+    }
+
+    private static class PeerTest extends AbstractPeer implements IPeer {
+
+        private int id;
+        private int rating;
+        private boolean connected;
+
+        public PeerTest(int id, int rating, boolean connected, IStatisticManager manager) throws URISyntaxException, UnknownServiceException {
+            super(new URI("aaa://"+id), manager);
+            this.id = id;
+            this.rating = rating;
+            this.connected = connected;
+            createPeerStatistics();
+        }
+
+        public void setRating(int rating) {
+            this.rating = rating;
+        }
+
+        public int getRating() {
+            return rating;
+        }
+
+        public long getHopByHopIdentifier() {
+            return 0;
+        }
+
+        public void addMessage(IMessage message) {
+
+        }
+
+        public void remMessage(IMessage message) {
+
+        }
+
+        public IMessage[] remAllMessage() {
+            return new IMessage[0];
+        }
+
+        public boolean handleMessage(EventTypes type, IMessage message, String key) throws TransportException, OverloadException, InternalException {
+            return false;
+        }
+
+        public boolean sendMessage(IMessage message) throws TransportException, OverloadException, InternalException {
+            return false;
+        }
+
+        public boolean hasValidConnection() {
+            return connected;
+        }
+
+        public void setRealm(String realm) {
+
+        }
+
+        public void addStateChangeListener(StateChangeListener listener) {
+
+        }
+
+        public void remStateChangeListener(StateChangeListener listener) {
+
+        }
+
+        public void addConnectionListener(IConnectionListener listener) {
+
+        }
+
+        public void remConnectionListener(IConnectionListener listener) {
+
+        }
+
+        public IStatistic getStatistic() {
+            return statistic;
+        }
+
+        public boolean isConnected() {
+            return connected;
+        }
+
+        public void connect() throws InternalException, IOException, IllegalDiameterStateException {
+
+        }
+
+        @Override
+        public void disconnect(int disconnectCause) throws InternalException, IllegalDiameterStateException {
+
+        }
+
+        public <E> E getState(Class<E> enumc) {
+            return null;
+        }
+
+        public URI getUri() {
+            return uri;
+        }
+
+        public InetAddress[] getIPAddresses() {
+            return new InetAddress[0];
+        }
+
+        public String getRealmName() {
+            return null;
+        }
+
+        public long getVendorId() {
+            return 0;
+        }
+
+        public String getProductName() {
+            return null;
+        }
+
+        public long getFirmware() {
+            return 0;
+        }
+
+        public Set<ApplicationId> getCommonApplications() {
+            return null;
+        }
+
+        public void addPeerStateListener(PeerStateListener listener) {
+
+        }
+
+        public void removePeerStateListener(PeerStateListener listener) {
+
+        }
+
+        @Override
+        public String toString() {
+            return "Peer-"+id;
+        }
+    }
+
+}

--- a/core/jdiameter/impl/src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml
+++ b/core/jdiameter/impl/src/test/resources/jdiameter-weightedroundrobinresubmitting-config.xml
@@ -1,0 +1,160 @@
+<?xml version="1.0"?>
+
+<Configuration xmlns="http://www.jdiameter.org/jdiameter-client">
+
+    <!--
+    LocalPeer configuration
+
+    Each diameter node has a local peer that is e.g. announced during capability exchanges.
+    It also describes what diameter applications are provided by this particular stack.
+    -->
+    <LocalPeer>
+
+        <!-- Local IP description -->
+        <URI value="aaa://127.0.0.1:3868"/>
+        <IPAddress value="192.168.178.101"/>
+
+        <!-- Realm this client is assigned to -->
+        <Realm value="localpeer.2scale.net"/>
+
+        <!-- 2scale Vendor ID: 47420 -->
+        <VendorID value="47420"/>
+        <ProductName value="Test Diameter Stack"/>
+        <FirmwareRevision value="1"/>
+
+        <!-- Describes supported application IDs as client -->
+        <Applications>
+            <ApplicationID>
+                <VendorId value="10415"/>
+                <AuthApplId value="4"/>
+                <AcctApplId value="0"/>
+            </ApplicationID>
+        </Applications>
+    </LocalPeer>
+
+    <Parameters>
+        <!--
+        Determines whether the URI should be used as FQDN. If it is set to true, the stack expects
+        the destination/origin host to be in the format of "aaa://isdn.domain.com:3868" rather than the
+        normal "isdn.domain.com". The default value is false. -->
+        <UseUriAsFqdn value="true" /> <!-- Needed for Ericsson Emulator (set to true) -->
+
+        <!--
+        Determines how many tasks the peer state machine can have before rejecting the next task.
+        This queue contains FSM events and messaging.
+        -->
+        <QueueSize value="10000"/>
+
+        <!--
+        Determines the timeout for messages other than protocol FSM messages. The delay is in milliseconds.
+        -->
+        <MessageTimeOut value="60000"/>
+
+        <!--
+        Determines how long the stack waits for all resources to stop. The delays are in milliseconds.
+        -->
+        <StopTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for CER/CEA exchanges to timeout if there is no response.
+        The delays are in milliseconds.
+        -->
+        <CeaTimeOut value="10000"/>
+
+        <!--
+        Determines how long the stack waits to retry the communication with a peer that has stopped answering
+        DWR messages. The delay is in milliseconds.
+        -->
+        <IacTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DWR/DWA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DwaTimeOut value="10000"/>
+
+        <!--
+        Determines how long it takes for a DPR/DPA exchange to timeout if there is no response.
+        The delay is in milliseconds.
+        -->
+        <DpaTimeOut value="5000"/>
+
+        <!--
+        Determines how long it takes for the reconnection procedure to timeout. The delay is in milliseconds.
+        -->
+        <RecTimeOut value="10000"/>
+
+        <!-- Statistics Logger Configuration -->
+        <Statistics pause="5000" delay="5000" enabled="true"
+                    active_records="Concurrent,ScheduledExecService,Network,ScheduledExecService,AppGenRequestPerSecond,NetGenRequestPerSecond,Peer,Peer.local,PeerFSM"/>
+
+        <!--Concurrent>
+            <Entity name="ThreadGroup" size="64"/>
+            <Entity name="ProcessingMessageTimer" size="1"/>
+            <Entity name="DuplicationMessageTimer" size="1"/>
+            <Entity name="RedirectMessageTimer" size="1"/>
+            <Entity name="PeerOverloadTimer" size="1"/>
+            <Entity name="ConnectionTimer" size="1"/>
+            <Entity name="StatisticTimer" size="1"/>
+        </Concurrent-->
+
+    </Parameters>
+
+    <!--
+        The <Network> element contains elements that specify parameters for external peers.
+        The available elements and attributes are listed for reference.
+    -->
+    <Network>
+
+        <!--
+        Parent element containing the child element <Peer>, which specifies external peers and the way they connect
+        -->
+        <Peers>
+            <!--
+            <Peer> specifies the name of external peers, whether they should be treated as a server or client,
+            and what rating the peer has externally.
+            <Peer> supports the following properties:
+                name Specifies the name of the peer in the form of a URI.
+                     The structure is "aaa://[fqdn|ip]:port" (for example, "aaa://192.168.1.1:3868").
+                attempt_connect Determines if the stack should try to connect to this peer.
+                                This property accepts boolean values.
+                rating Specifies the rating of this peer in order to achieve peer priorities/sorting.
+            -->
+            <Peer name="aaa://127.0.0.1:13868" rating="1"/>
+            <Peer name="aaa://127.0.0.2:13868" rating="2"/>
+        </Peers>
+
+        <!--
+           Parent element containing the child element <Realm>, which specifies all realms that connect into the
+           Diameter network. <Realm> contains attributes and elements that describe different realms configured
+           for the Core. It supports <ApplicationID> child elements, which define the applications supported.
+        -->
+        <Realms>
+            <!--
+                <Realm> supports the following parameters:
+                peers
+                    Comma separated list of peers. Each peer is represented by an IP Address or FQDN.
+                local_action
+                    Determines the action the Local Peer will play on the specified realm: Act as a LOCAL peer.
+                dynamic
+                    Specifies if this realm is dynamic.
+                    That is, peers that connect to peers with this realm name will be added to the realm peer
+                    list if not present already.
+                exp_time
+                    The time before a peer belonging to this realm is removed if no connection is available.
+            -->
+            <Realm name="remotepeer.2scale.net" peers="127.0.0.1" local_action="LOCAL" dynamic="false" exp_time="1">
+                <ApplicationID>
+                    <VendorId value="10415" />
+                    <AuthApplId value="4" />
+                    <AcctApplId value="0" />
+                </ApplicationID>
+            </Realm>
+        </Realms>
+    </Network>
+
+    <Extensions>
+        <RouterEngine value="org.jdiameter.client.impl.router.WeightedRoundRobinResubmittingRouter" />
+    </Extensions>
+
+</Configuration>

--- a/core/jdiameter/impl/src/test/resources/log4j.properties
+++ b/core/jdiameter/impl/src/test/resources/log4j.properties
@@ -1,0 +1,9 @@
+# Set root logger level to DEBUG and its only appender to A1.
+log4j.rootLogger=TRACE, A1
+
+# A1 is set to be a ConsoleAppender.
+log4j.appender.A1=org.apache.log4j.ConsoleAppender
+
+# A1 uses PatternLayout.
+log4j.appender.A1.layout=org.apache.log4j.PatternLayout
+log4j.appender.A1.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n


### PR DESCRIPTION
The IRouter interface now has a new method, processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) which can be called to send a request, which initially received a 3002 or 3004 response from one peer, to an alternate peer.

The PeerImpl class now has a helper method, isBusyOrUnableToDeliverAnswer(Avp avpResCode, IMessage answer), to unambiguously determine whether a response can be considered a Busy or Unable to Deliver response (quite simply whether the response was 3002 or 3004). A second method has also been added to this class, processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table), which simply delegates resubmission to the IRouter's new processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) method, when the Router Implementation supports this (see below [^1] for details).

In the PeerImpl's connect() method, the above two methods are used to determine whether a response was a Busy or Unable to deliver response, and, when this is the case, delegates resubmission to the IRouter's new processBusyOrUnableToDeliverAnswer(IRequest request, IPeerTable table) method.

In RouterImpl, an overloaded method selectPeer(IMessage message, List<IPeer> availablePeers) has been added, to allow the default RouterImpl and subclasses (WeightedRoundRobinRouter & WeightedLeastConnectionsRouter) to resend the original request after selecting an alternate peer. In the default PeerImpl and the other existing subclasses, this overloaded method simply calls selectPeer(List<IPeer> availablePeers), in order to maintain the original behaviour.

A new Router class has been defined, WeightedRoundRobinResubmittingRouter, into which the actual functionality has been implemented. This has been copied from WeightedRoundRobinRouter. This new class was defined in order to protect existing users from any possible undesirable side-effects from changes in routing functionality. So, in order to have Busy or Unable to Deliver responses retried on alternate peers, the WeightedRoundRobinResubmittingRouter needs to be configured as the chosen RouterEngine in the Extensions section of the jDiameter config.

The WeightedRoundRobinResubmittingRouter will select alternate peers for resubmissions, until all peers have been exhausted for any given request, while respecting the Weighted Round Robin balancing algorithm.

[^1] To allow the PeerImpl to determine whether or not any particular Router implementation supports resubmissions, a method canProcessBusyOrUnableToDeliverAnswer() has been added to the IRouter interface. This method is implemented in RouterImpl to return false by default and must be overridden by classes supporting this functionality (currently only the WeightedRoundRobinResubmittingRouter).

It may be desirable to merge the functionality into the existing Router classes, rather than to have it exclusively in the newly defined WeightedRoundRobinResubmittingRouter. Please let me know whether this should be done.

Regarding Unit Testing:

The TestRouter class has been extended with Unit Tests covering various scenarios which the WeightedRoundRobinResubmittingRouter may encounter. The existing tests remain unchanged. TestRouter now extends junit.framework.TestCase, to ensure that the tests are run every time a Maven build is performed.

A log4j.properties file has been added to allow all logging output from classes under test to be directed to a ConsoleAppender.

Furthermore:
All code has been reformatted according to the Restcomm checkstyle standards.
