### PR TITLE
Fixing "loop" during redirect

### DIFF
--- a/core/jdiameter/api/src/main/java/org/jdiameter/api/Avp.java
+++ b/core/jdiameter/api/src/main/java/org/jdiameter/api/Avp.java
@@ -2761,6 +2761,17 @@ public interface Avp extends Wrapper, Serializable {
   // Service-Area-Identity 1607 3GPP TS 29.272;
   // GMLC-Address 2405 3GPP TS 29.173;
   // Visited-PLMN-Id 1407 3GPP TS 29.272
+  
+  /********************************************************/
+  /*** SWm interface (3GPP AAA - AGW) AVPs (3GPP TS 29.273) ***/
+  /*** Diameter SWM Application (EAP Protocol) ***/
+  /********************************************************/
+
+  /**
+   * SWm (3GPP TS 29.273-f10) AAA-Failure-Indication AVP code
+   */
+  int AAA_FAILURE_INDICATION = 1518;
+  
 
   /**
    * @return the AVP code.


### PR DESCRIPTION
Detect the “loop” in case of getting DEA (Diameter Eap Answer) with code 3006 (DIAMETER_REDIRECT_INDICATION) and setting the additional AAA_FAILURE_INDICATION  AVP (1518) in the following DER in order to break it.
Loop means that the original DER was already sent with the same Destination-Host AVP which appears in DEA as Redirect-Host AVP.