### PR TITLE
Implement SCTP multi-homing for JDiameter, both client and server

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/sctp/SCTPTransportClient.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/client/impl/transport/sctp/SCTPTransportClient.java
@@ -55,6 +55,8 @@ public class SCTPTransportClient {
   private String clientAssociationName;
   protected InetSocketAddress destAddress;
   protected InetSocketAddress origAddress;
+
+  protected String[] extraHostAddresses;
   private int payloadProtocolId = 0;
   private int streamNumber = 0;
 
@@ -109,7 +111,7 @@ public class SCTPTransportClient {
             clientAssociationName, origAddress, destAddress });
         this.clientAssociation = this.management.addAssociation(origAddress.getAddress().getHostAddress(),
             origAddress.getPort(), destAddress.getAddress().getHostAddress(), destAddress.getPort(), clientAssociationName,
-            IpChannelType.SCTP, null);
+            IpChannelType.SCTP, extraHostAddresses);
       }
       else {
         logger.debug("CLIENT ASSOCIATION '{}'. Origin Address [{}:{}] <=> Dest Address [{}:{}] already present. Re-using it.",
@@ -287,6 +289,19 @@ public class SCTPTransportClient {
 
   public InetSocketAddress getOrigAddress() {
     return this.origAddress;
+  }
+
+  public void setExtraHostAddresses(String[] extraHostAddresses) {
+    this.extraHostAddresses = extraHostAddresses;
+    if (logger.isDebugEnabled() && extraHostAddresses != null) {
+      for(final String address : extraHostAddresses) {
+        logger.debug("Extra host address is set to [{}]", address);
+      }
+    }
+  }
+
+  public String[] getExtraHostAddresses() {
+    return this.extraHostAddresses;
   }
 
   public void sendMessage(ByteBuffer bytes) throws IOException {

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/NetworkGuard.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/NetworkGuard.java
@@ -73,10 +73,19 @@ public class NetworkGuard implements INetworkGuard {
     this.serverConnections = new ArrayList<SCTPServerConnection>();
 
     try {
-      for (InetAddress ia : inetAddresses) {
-        final SCTPServerConnection sctpServerConnection = new SCTPServerConnection(null, ia, port, parser, null, this);
-        this.serverConnections.add(sctpServerConnection);
+      if (localAddresses.length < 1) {
+        throw new Exception("Need at least one IP address configured");
+      } else if (localAddresses.length > 4) {
+        throw new IllegalArgumentException("Maximum of 4 IPAddress attributes allowed");
       }
+
+      final InetAddress firstAddress = localAddresses[0];
+      final String[] extraHostAddresses = localAddresses.length > 1 ? new String[localAddresses.length - 1] : null;
+      for(int i = 1; i < localAddresses.length; i++) {
+        extraHostAddresses[i - 1] = localAddresses[i].getHostAddress();
+      }
+      final SCTPServerConnection sctpServerConnection = new SCTPServerConnection(null, firstAddress, port, parser, null, this, extraHostAddresses);
+      this.serverConnections.add(sctpServerConnection);
     }
     catch (Exception exc) {
       try {

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/SCTPServerConnection.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/SCTPServerConnection.java
@@ -72,11 +72,12 @@ public class SCTPServerConnection implements IConnection {
 
   // this creates the listening server - no dest address is passed it is automatically 0.0.0.0:0
   public SCTPServerConnection(Configuration config, InetAddress localAddress, int localPort, IMessageParser parser, String ref,
-      NetworkGuard guard) throws Exception {
+      NetworkGuard guard, String[] extraHostAddresses) throws Exception {
     this(parser, guard);
 
     logger.debug("SCTP Server constructor for listening server @ {}:{}", localAddress, localPort);
     server.setOrigAddress(new InetSocketAddress(localAddress, localPort));
+    server.setExtraHostAddresses(extraHostAddresses);
     server.startServer();
   }
 

--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/SCTPTransportServer.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/io/sctp/SCTPTransportServer.java
@@ -53,6 +53,7 @@ public class SCTPTransportServer {
   private String serverName;
   protected InetSocketAddress destAddress;
   protected InetSocketAddress origAddress;
+  protected String[] extraHostAddresses;
   private Server server = null;
   private static final Logger logger = LoggerFactory.getLogger(SCTPTransportServer.class);
   private int payloadProtocolId = 0;
@@ -161,7 +162,7 @@ public class SCTPTransportServer {
       // We don't have any, let's create it
       if (server == null) {
         server = this.management.addServer(serverName, origAddress.getAddress().getHostAddress(), origAddress.getPort(),
-            IpChannelType.SCTP, true, 10, null);
+            IpChannelType.SCTP, true, 10, extraHostAddresses);
       }
 
       for (String assocName : server.getAssociations()) {
@@ -378,6 +379,15 @@ public class SCTPTransportServer {
     this.origAddress = address;
     if (logger.isDebugEnabled()) {
       logger.debug("Origin address is set to [{}:{}]", origAddress.getHostName(), origAddress.getPort());
+    }
+  }
+
+  public void setExtraHostAddresses(String[] extraHostAddresses) {
+    this.extraHostAddresses = extraHostAddresses;
+    if (logger.isDebugEnabled() && extraHostAddresses != null) {
+      for(final String address : extraHostAddresses) {
+        logger.debug("Extra host address is set to [{}]", address);
+      }
     }
   }
 


### PR DESCRIPTION
JDiameter support for up to 4 IP addresses on SCTP level for both server and client.

This fixes #25 and #130
`
        <IPAddresses>
            <IPAddress value="127.0.0.5" />
            <IPAddress value="172.18.202.20" />
        </IPAddresses>` 

Yields (server/network guard):

`$ cat /proc/net/sctp/eps 
 ENDPT     SOCK   STY SST HBKT LPORT   UID INODE LADDRS
       0        0 2   10  29   8085   1000 173827 127.0.0.5 172.18.202.20 
`
And (client):

`$ cat /proc/net/sctp/assocs 
 ASSOC     SOCK   STY SST ST HBKT ASSOC-ID TX_QUEUE RX_QUEUE UID INODE LPORT RPORT LADDRS <-> RADDRS HBINT INS OUTS MAXRT T1X T2X RTXC wmema wmemq sndbuf rcvbuf
       0        0 2   1   3  0       5        0        0    1000 181270 20836  3868  127.0.0.5 172.18.202.20 <-> *127.0.0.1 192.168.178.25 192.168.122.1 192.168.0.1 172.18.202.20          7500    30    32   10    0    0        0        1        0   212992   212992
`
