### PR TITLE
Get session state after lock acquiring, release session on error

### DIFF
--- a/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/app/ro/ServerRoSessionImpl.java
+++ b/core/jdiameter/impl/src/main/java/org/jdiameter/server/impl/app/ro/ServerRoSessionImpl.java
@@ -151,9 +151,11 @@ public class ServerRoSessionImpl extends AppRoSessionImpl implements ServerRoSes
   @Override
   public boolean handleEvent(StateEvent event) throws InternalException, OverloadException {
     ServerRoSessionState newState = null;
-    ServerRoSessionState state = sessionData.getServerRoSessionState();
     try {
       sendAndStateLock.lock();
+
+      // Get state after lock acquiring
+      ServerRoSessionState state = sessionData.getServerRoSessionState();
 
       // Can be null if there is no state transition, transition to IDLE state should terminate this app session
       Event localEvent = (Event) event;
@@ -224,6 +226,10 @@ public class ServerRoSessionImpl extends AppRoSessionImpl implements ServerRoSes
             case RECEIVED_TERMINATE:
               Answer errorAnswer = ((Request) localEvent.getRequest().getMessage()).createAnswer(ResultCode.UNKNOWN_SESSION_ID);
               session.send(errorAnswer);
+
+              // release this session
+              release();
+
               logger.debug("Received an UPDATE or TERMINATE for a new session. Answering with 5002 (UNKNOWN_SESSION_ID) and terminating session.");
               // and let it throw exception anyway ...
             default:


### PR DESCRIPTION
Fixed 2 bugs:
1. if IServerRoSessionData.setServerRoSessionState relatively slow, we cat get outdated state before lock and process request with incorrect state
2. if server receive CCR-U/CCR-T on non-existent session (unknown session-id), he creates session in LocalDataSource.sessionIdToEntry, but never removes it